### PR TITLE
Fix missing comma in service worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -5,7 +5,7 @@ const STATIC_FILES = [
   '/',
   '/index.html',
   '/chat.html',
-  '/styles.css'
+  '/styles.css',
   '/manifest.json',
 ];
 


### PR DESCRIPTION
## Summary
- ensure `STATIC_FILES` includes commas between each entry in the service worker

## Testing
- `npm test` *(fails due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_687181ba29f4832ba154341f5bc868b3