### PR TITLE
Add TypeScript server build and start scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,15 @@ This project is a simple Node.js/Express application that demonstrates how an AI
    ```bash
    npm install
    ```
-2. Start the server:
+2. (Optional) build the TypeScript server:
+   ```bash
+   npm run build
+   ```
+3. Start the server:
    ```bash
    npm start
    ```
-3. Run tests:
+4. Run tests:
    ```bash
    npm test
    ```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "AI powered help desk using Express and n8n",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js",
+    "start": "ts-node src/server/index.ts",
+    "build": "tsc -p src/server",
     "test": "env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY -u npm_config_http_proxy -u npm_config_https_proxy -u npm_config_proxy -u YARN_HTTP_PROXY -u YARN_HTTPS_PROXY sh -c 'for f in tests/*.test.js; do node \"$f\" || exit 1; done'",
     "format": "prettier \"**/*.{js,json,md}\" --write",
     "migrate": "node migrate.js"
@@ -13,6 +14,8 @@
     "mssql": "^10.0.0"
   },
   "devDependencies": {
-    "prettier": "^3.0.0"
+    "prettier": "^3.0.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.0"
   }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,20 @@
+import express from '../../express';
+import bodyParser from '../../body-parser';
+import authRoutes from './routes/auth';
+import { config } from './config/environment';
+
+const app = express();
+app.use(bodyParser.json());
+app.use('/auth', authRoutes);
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+if (require.main === module) {
+  app.listen(config.server.port, () => {
+    console.log(`Server running on port ${config.server.port}`);
+  });
+}
+
+export default app;

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "rootDir": "./",
+    "outDir": "../../dist/server",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add ts-node start script and tsc build script
- document building and starting the TypeScript server
- include tsconfig and a minimal server entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687181e94504832ba21050b353355124