### PR TITLE
Add dark mode and loading UX improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,18 +19,9 @@
   },
   "devDependencies": {
     "prettier": "^3.0.0",
-
     "ts-node": "^10.9.1",
-    "typescript": "^5.2.0"
-
-
-    "ts-node": "^10.9.1",
-
     "typescript": "^5.2.0",
-    "ts-node": "^10.9.1",
     "@types/node": "^20.4.2",
     "@types/express": "^4.17.17"
-
-
   }
 }

--- a/public/chat.html
+++ b/public/chat.html
@@ -16,6 +16,7 @@
     <nav>
       <a href="/index.html">Home</a>
     </nav>
+    <button id="themeToggle" type="button" aria-label="Toggle dark mode">🌓</button>
   </header>
   <main id="main">
     <div id="messages" role="log" aria-live="polite"></div>
@@ -64,6 +65,18 @@
         voiceBtn.style.display = 'none';
       }
     }
+
+    // Dark mode toggle
+    const themeToggle = document.getElementById('themeToggle');
+    function applyTheme(theme) {
+      document.body.classList.toggle('dark', theme === 'dark');
+    }
+    themeToggle.addEventListener('click', () => {
+      const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
+      applyTheme(newTheme);
+      localStorage.setItem('theme', newTheme);
+    });
+    applyTheme(localStorage.getItem('theme') || 'light');
 
     // Register service worker
     if ('serviceWorker' in navigator) {

--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,7 @@
     <nav>
       <a href="/chat.html">AI Chat</a>
     </nav>
+    <button id="themeToggle" type="button" aria-label="Toggle dark mode">🌓</button>
   </header>
   <main id="main">
 
@@ -51,10 +52,19 @@
       });
     }
 
-    document.getElementById('load').onclick = async () => {
-      const res = await fetch('/tickets');
-      const tickets = await res.json();
-      renderTickets(tickets);
+    const loadBtn = document.getElementById('load');
+    loadBtn.onclick = async () => {
+      loadBtn.disabled = true;
+      const original = loadBtn.textContent;
+      loadBtn.textContent = 'Loading...';
+      try {
+        const res = await fetch('/tickets');
+        const tickets = await res.json();
+        renderTickets(tickets);
+      } finally {
+        loadBtn.textContent = original;
+        loadBtn.disabled = false;
+      }
     };
 
     document.getElementById('searchForm').onsubmit = async e => {
@@ -103,6 +113,18 @@
     }
 
     loadStats();
+
+    // Dark mode toggle
+    const themeToggle = document.getElementById('themeToggle');
+    function applyTheme(theme) {
+      document.body.classList.toggle('dark', theme === 'dark');
+    }
+    themeToggle.addEventListener('click', () => {
+      const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
+      applyTheme(newTheme);
+      localStorage.setItem('theme', newTheme);
+    });
+    applyTheme(localStorage.getItem('theme') || 'light');
 
     // Register service worker for offline support
     if ('serviceWorker' in navigator) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,20 +1,43 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --border-color: #ccc;
+  --link-color: #005fcc;
+}
+
 body {
   font-family: Arial, sans-serif;
   max-width: 800px;
   margin: auto;
   padding: 1rem;
+  background: var(--bg-color);
+  color: var(--text-color);
+}
+
+body.dark {
+  --bg-color: #121212;
+  --text-color: #e0e0e0;
+  --border-color: #444;
+  --link-color: #9fc5e8;
 }
 nav {
   margin-bottom: 1em;
 }
 nav a {
   margin-right: 1em;
+  color: var(--link-color);
+}
+a {
+  color: var(--link-color);
 }
 #tickets {
   margin-top: 1em;
 }
 button {
   padding: 0.5em 1em;
+}
+#themeToggle {
+  margin-left: 1em;
 }
 
 
@@ -48,7 +71,7 @@ input:focus-visible {
 
 }
 #messages {
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   padding: 1em;
   height: 300px;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- improve `package.json` formatting
- add dark mode toggle across HTML pages
- show loading state when fetching tickets
- use CSS variables for light/dark themes

## Testing
- `npm test` *(fails: Aging tickets test passed)*

------
https://chatgpt.com/codex/tasks/task_e_6871bc08bfc4832bb424248afb312122