### PR TITLE
Add sidebar nav and realtime ticket refresh

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -13,12 +13,24 @@
   <a href="#main" class="skip-link">Skip to content</a>
 
   <header class="flex justify-between items-center py-4">
-    <h1 class="text-2xl font-bold">AI Chat</h1>
-    <nav>
-      <a href="/index.html" class="text-blue-600 hover:underline">Home</a>
+    <div class="flex items-center gap-2">
+      <button id="menuToggle" aria-controls="sidebar" aria-expanded="false" class="border p-2 md:hidden">☰</button>
+      <h1 class="text-2xl font-bold">AI Chat</h1>
+    </div>
+    <nav class="hidden md:block">
+      <a href="/index.html" class="text-blue-600 hover:underline mr-4">Home</a>
+      <a href="/realtime.html" class="text-blue-600 hover:underline">Real-Time</a>
     </nav>
     <button id="themeToggle" type="button" aria-label="Toggle dark mode" class="ml-4">🌓</button>
   </header>
+
+  <nav id="sidebar" aria-label="Sidebar" class="fixed inset-y-0 left-0 w-56 bg-gray-100 dark:bg-gray-900 p-4 transform -translate-x-full transition-transform md:static md:translate-x-0 md:w-48">
+    <ul class="space-y-2">
+      <li><a href="/index.html" class="block hover:underline">Dashboard</a></li>
+      <li><a href="/chat.html" class="block hover:underline">AI Chat</a></li>
+      <li><a href="/realtime.html" class="block hover:underline">Real-Time</a></li>
+    </ul>
+  </nav>
   <main id="main" class="mt-4">
     <div id="messages" role="log" aria-live="polite" class="border p-4 h-72 overflow-y-auto mb-4"></div>
     <form id="chatForm" class="flex gap-2">
@@ -72,17 +84,28 @@
     function applyTheme(theme) {
       document.body.classList.toggle('dark', theme === 'dark');
     }
-    themeToggle.addEventListener('click', () => {
-      const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
-      applyTheme(newTheme);
-      localStorage.setItem('theme', newTheme);
-    });
-    applyTheme(localStorage.getItem('theme') || 'light');
+  themeToggle.addEventListener('click', () => {
+    const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
+    applyTheme(newTheme);
+    localStorage.setItem('theme', newTheme);
+  });
+  applyTheme(localStorage.getItem('theme') || 'light');
 
-    // Register service worker
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js');
-    }
+  // Sidebar toggle
+  const sidebar = document.getElementById('sidebar');
+  const menuToggle = document.getElementById('menuToggle');
+  if (menuToggle) {
+    menuToggle.addEventListener('click', () => {
+      const open = sidebar.classList.toggle('open');
+      sidebar.classList.toggle('-translate-x-full', !open);
+      menuToggle.setAttribute('aria-expanded', open);
+    });
+  }
+
+  // Register service worker
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/sw.js');
+  }
   </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -14,12 +14,24 @@
   <a href="#main" class="skip-link">Skip to content</a>
 
   <header class="flex justify-between items-center py-4">
-    <h1 class="text-2xl font-bold">AI Powered Help Desk</h1>
-    <nav>
-      <a href="/chat.html" class="text-blue-600 hover:underline">AI Chat</a>
+    <div class="flex items-center gap-2">
+      <button id="menuToggle" aria-controls="sidebar" aria-expanded="false" class="border p-2 md:hidden">☰</button>
+      <h1 class="text-2xl font-bold">AI Powered Help Desk</h1>
+    </div>
+    <nav class="hidden md:block">
+      <a href="/chat.html" class="text-blue-600 hover:underline mr-4">AI Chat</a>
+      <a href="/realtime.html" class="text-blue-600 hover:underline">Real-Time</a>
     </nav>
     <button id="themeToggle" type="button" aria-label="Toggle dark mode" class="ml-4">🌓</button>
   </header>
+
+  <nav id="sidebar" aria-label="Sidebar" class="fixed inset-y-0 left-0 w-56 bg-gray-100 dark:bg-gray-900 p-4 transform -translate-x-full transition-transform md:static md:translate-x-0 md:w-48">
+    <ul class="space-y-2">
+      <li><a href="/index.html" class="block hover:underline">Dashboard</a></li>
+      <li><a href="/chat.html" class="block hover:underline">AI Chat</a></li>
+      <li><a href="/realtime.html" class="block hover:underline">Real-Time</a></li>
+    </ul>
+  </nav>
   <main id="main" class="mt-4">
 
     <section id="stats" aria-live="polite" class="mb-6">
@@ -168,24 +180,42 @@
       }
     }
 
-    loadStats();
+  loadStats();
 
-    // Dark mode toggle
-    const themeToggle = document.getElementById('themeToggle');
-    function applyTheme(theme) {
-      document.body.classList.toggle('dark', theme === 'dark');
-    }
-    themeToggle.addEventListener('click', () => {
-      const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
-      applyTheme(newTheme);
-      localStorage.setItem('theme', newTheme);
+  // Dark mode toggle
+  const themeToggle = document.getElementById('themeToggle');
+  function applyTheme(theme) {
+    document.body.classList.toggle('dark', theme === 'dark');
+  }
+  themeToggle.addEventListener('click', () => {
+    const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
+    applyTheme(newTheme);
+    localStorage.setItem('theme', newTheme);
+  });
+  applyTheme(localStorage.getItem('theme') || 'light');
+
+  // Sidebar toggle
+  const sidebar = document.getElementById('sidebar');
+  const menuToggle = document.getElementById('menuToggle');
+  if (menuToggle) {
+    menuToggle.addEventListener('click', () => {
+      const open = sidebar.classList.toggle('open');
+      sidebar.classList.toggle('-translate-x-full', !open);
+      menuToggle.setAttribute('aria-expanded', open);
     });
-    applyTheme(localStorage.getItem('theme') || 'light');
+  }
 
-    // Register service worker for offline support
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js');
-    }
+  // Real-time ticket updates
+  if (window.EventSource) {
+    const es = new EventSource('/events');
+    es.addEventListener('ticketCreated', loadTickets);
+    es.addEventListener('ticketUpdated', loadTickets);
+  }
+
+  // Register service worker for offline support
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/sw.js');
+  }
   </script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -14,6 +14,29 @@ body {
   color: var(--text-color);
 }
 
+#sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: var(--bg-color);
+  color: var(--text-color);
+  transform: translateX(-100%);
+  transition: transform 0.2s ease;
+  z-index: 50;
+}
+#sidebar.open {
+  transform: translateX(0);
+}
+@media (min-width: 768px) {
+  #sidebar {
+    position: static;
+    transform: none;
+    height: auto;
+    width: 200px;
+  }
+}
+
 body.dark {
   --bg-color: #121212;
   --text-color: #e0e0e0;

--- a/public/ticket.html
+++ b/public/ticket.html
@@ -11,12 +11,24 @@
 <body>
   <a href="#main" class="skip-link">Skip to content</a>
   <header class="flex justify-between items-center py-4">
-    <h1 class="text-2xl font-bold">Ticket Details</h1>
-    <nav>
-      <a href="/index.html" class="text-blue-600 hover:underline">Home</a>
+    <div class="flex items-center gap-2">
+      <button id="menuToggle" aria-controls="sidebar" aria-expanded="false" class="border p-2 md:hidden">☰</button>
+      <h1 class="text-2xl font-bold">Ticket Details</h1>
+    </div>
+    <nav class="hidden md:block">
+      <a href="/index.html" class="text-blue-600 hover:underline mr-4">Home</a>
+      <a href="/realtime.html" class="text-blue-600 hover:underline">Real-Time</a>
     </nav>
     <button id="themeToggle" type="button" aria-label="Toggle dark mode" class="ml-4">🌓</button>
   </header>
+
+  <nav id="sidebar" aria-label="Sidebar" class="fixed inset-y-0 left-0 w-56 bg-gray-100 dark:bg-gray-900 p-4 transform -translate-x-full transition-transform md:static md:translate-x-0 md:w-48">
+    <ul class="space-y-2">
+      <li><a href="/index.html" class="block hover:underline">Dashboard</a></li>
+      <li><a href="/chat.html" class="block hover:underline">AI Chat</a></li>
+      <li><a href="/realtime.html" class="block hover:underline">Real-Time</a></li>
+    </ul>
+  </nav>
   <main id="main" class="prose max-w-none">
     <div id="details"></div>
   </main>
@@ -25,16 +37,27 @@
     function applyTheme(theme) {
       document.body.classList.toggle('dark', theme === 'dark');
     }
-    themeToggle.addEventListener('click', () => {
-      const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
-      applyTheme(newTheme);
-      localStorage.setItem('theme', newTheme);
-    });
-    applyTheme(localStorage.getItem('theme') || 'light');
+  themeToggle.addEventListener('click', () => {
+    const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
+    applyTheme(newTheme);
+    localStorage.setItem('theme', newTheme);
+  });
+  applyTheme(localStorage.getItem('theme') || 'light');
 
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js');
-    }
+  // Sidebar toggle
+  const sidebar = document.getElementById('sidebar');
+  const menuToggle = document.getElementById('menuToggle');
+  if (menuToggle) {
+    menuToggle.addEventListener('click', () => {
+      const open = sidebar.classList.toggle('open');
+      sidebar.classList.toggle('-translate-x-full', !open);
+      menuToggle.setAttribute('aria-expanded', open);
+    });
+  }
+
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/sw.js');
+  }
 
     const params = new URLSearchParams(location.search);
     const id = params.get('id');


### PR DESCRIPTION
## Summary
- add collapsible sidebar with navigation links
- integrate EventSource on dashboard to refresh tickets automatically
- provide sidebar toggle on chat and ticket pages
- style sidebar in `styles.css`

## Testing
- `npm test` *(fails: Cannot find module 'mssql')*

------
https://chatgpt.com/codex/tasks/task_e_6872a82d2ed8832bb4763a1a4e8b8887