### PR TITLE
Add service URL vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,9 @@ RATE_LIMIT_MAX_REQUESTS=100
 # File Upload
 MAX_FILE_SIZE=10485760
 UPLOAD_PATH=./uploads
+
+# External Services
+# n8n workflow webhook URL
+N8N_URL=http://localhost:5678/webhook/ai
+# Qdrant server base URL
+QDRANT_URL=http://localhost:6333

--- a/README.md
+++ b/README.md
@@ -133,8 +133,10 @@ actual MSSQL database set `USE_MSSQL=true` in your `.env` file along with the
 standard `DB_*` connection settings. When enabled the `/tickets` and
 `/tickets/:id` endpoints read from the `V_Ticket_Master_Expanded` view.
 
-The n8n webhook URL can be configured via the `N8N_URL` environment variable.
-The Qdrant server URL can be set with the `QDRANT_URL` environment variable.
+Other useful environment variables include:
+
+- `N8N_URL` – n8n workflow webhook URL.
+- `QDRANT_URL` – base address of the Qdrant server.
 
 After the first visit, the pages are cached for offline use via a service worker.
 An experimental `realtime.html` page demonstrates live ticket notifications using the `/events` SSE endpoint.


### PR DESCRIPTION
## Summary
- add example N8N_URL and QDRANT_URL to `.env.example`
- document these variables in the README setup section

## Testing
- `npm test` *(fails: Aging tickets test passed then stalled)*

------
https://chatgpt.com/codex/tasks/task_e_687308890268832bb89d208df3f43600