### PR TITLE
Fix duplicate asset routes

### DIFF
--- a/server.js
+++ b/server.js
@@ -835,20 +835,6 @@ app.get("/assets/unassigned", (req, res) => {
   res.json(assets);
 });
 
-// Search assets by name
-app.get("/assets/search", (req, res) => {
-  const { q } = req.query;
-  if (!q) return res.json([]);
-  const query = q.toLowerCase();
-  const assets = (data.assets || []).filter((a) =>
-    a.name.toLowerCase().includes(query),
-  );
-  res.json(assets);
-});
-
-app.post("/assets", (req, res) => {
-  res.json(assets);
-});
 
 // Search assets by name
 


### PR DESCRIPTION
## Summary
- remove duplicate `GET /assets/search` implementation
- delete stray `POST /assets` handler
- keep the correct asset creation endpoint intact

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68730a74abf8832bad80109292128952