### PR TITLE
Implement Microsoft token validation

### DIFF
--- a/src/server/services/AuthService.ts
+++ b/src/server/services/AuthService.ts
@@ -257,7 +257,25 @@ class AuthService {
   }
 
   private async validateMicrosoftToken(token: string): Promise<MicrosoftUserData> {
-    throw new Error('Microsoft token validation not implemented');
+    const response = await fetch('https://graph.microsoft.com/v1.0/me', {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to validate Microsoft token');
+    }
+
+    const data = await response.json();
+
+    return {
+      objectId: data.id,
+      email: data.mail || data.userPrincipalName,
+      displayName: data.displayName,
+      firstName: data.givenName,
+      lastName: data.surname
+    };
   }
 
   private async createMicrosoftUser(microsoftUser: MicrosoftUserData): Promise<User> {

--- a/tests/microsoftAuthFailure.test.js
+++ b/tests/microsoftAuthFailure.test.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+const AuthService = require('../dist/server/services/AuthService.js').default;
+
+const service = new AuthService();
+
+// mock fetch for failure
+global.fetch = async () => ({ ok: false, status: 401 });
+
+service.validateMicrosoftToken('badtoken')
+  .then(() => {
+    console.error('Expected error not thrown');
+    process.exit(1);
+  })
+  .catch(err => {
+    assert.ok(err instanceof Error);
+    console.log('Microsoft token failure test passed');
+  });

--- a/tests/microsoftAuthSuccess.test.js
+++ b/tests/microsoftAuthSuccess.test.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+const AuthService = require('../dist/server/services/AuthService.js').default;
+
+const service = new AuthService();
+
+// mock fetch for successful response
+global.fetch = async (url, opts) => {
+  assert.strictEqual(url, 'https://graph.microsoft.com/v1.0/me');
+  return {
+    ok: true,
+    async json() {
+      return {
+        id: 'user-123',
+        mail: 'user@example.com',
+        displayName: 'Example User',
+        givenName: 'Example',
+        surname: 'User'
+      };
+    }
+  };
+};
+
+service.validateMicrosoftToken('token').then(user => {
+  assert.deepStrictEqual(user, {
+    objectId: 'user-123',
+    email: 'user@example.com',
+    displayName: 'Example User',
+    firstName: 'Example',
+    lastName: 'User'
+  });
+  console.log('Microsoft token success test passed');
+}).catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- validate Microsoft identity tokens using the Graph API
- add tests for success and failure Microsoft authentication flows

## Testing
- `node tests/microsoftAuthSuccess.test.js`
- `node tests/microsoftAuthFailure.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68730a75d8a0832baa817ab41c3d30eb