### PR TITLE
Add user profile page with API

### DIFF
--- a/docs/DECISION_LOG.md
+++ b/docs/DECISION_LOG.md
@@ -265,3 +265,8 @@
 - **Date:** 2025-07-23
 - **Reasoning:** Duplicate service worker registration scripts caused unnecessary network requests.
 - **Impact:** Cleaned up HTML and added manifest to cache for smoother offline experience.
+
+### Added user profile API and page
+- **Date:** 2025-07-24
+- **Reasoning:** Needed a consolidated view of tickets and assets for individual users.
+- **Impact:** New endpoints `/users/:id/tickets` and `/users/:id/assets` expose this data and a React `UserProfile` page displays it.

--- a/docs/FRONTEND_CHANGELOG.md
+++ b/docs/FRONTEND_CHANGELOG.md
@@ -43,3 +43,7 @@
 ## [2025-07-23] Service worker tweaks
 - Removed duplicate service worker registration scripts from HTML pages.
 - Cached `manifest.json` for offline support.
+
+## [2025-07-24] Added user profile page
+- Introduced `UserProfile.tsx` reachable at `/users/:id` displaying tickets and assets for the selected user.
+- Navigation menu now links to the profile page.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Link, Route, Routes } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import Analytics from './pages/Analytics';
+import UserProfile from './pages/UserProfile';
 import ThemeToggle from './ThemeToggle';
 import CommandPalette from './components/CommandPalette';
 
@@ -12,13 +13,15 @@ export default function App() {
         <h1 className="text-2xl font-bold">AI Help Desk</h1>
         <nav>
           <Link to="/" className="mr-4 text-blue-600 hover:underline">Dashboard</Link>
-          <Link to="/analytics" className="text-blue-600 hover:underline">Analytics</Link>
+          <Link to="/analytics" className="mr-4 text-blue-600 hover:underline">Analytics</Link>
+          <Link to="/users/1" className="text-blue-600 hover:underline">Profile</Link>
         </nav>
         <ThemeToggle />
       </header>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/analytics" element={<Analytics />} />
+        <Route path="/users/:id" element={<UserProfile />} />
       </Routes>
       <CommandPalette />
     </BrowserRouter>

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+interface Ticket {
+  id: number;
+  question: string;
+  status: string;
+}
+
+interface Asset {
+  id: number;
+  name: string;
+}
+
+export default function UserProfile() {
+  const { id } = useParams<{ id: string }>();
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [assets, setAssets] = useState<Asset[]>([]);
+
+  useEffect(() => {
+    document.title = 'User Profile - AI Help Desk';
+  }, []);
+
+  useEffect(() => {
+    if (!id) return;
+    async function load() {
+      const [tRes, aRes] = await Promise.all([
+        fetch(`/users/${id}/tickets`),
+        fetch(`/users/${id}/assets`),
+      ]);
+      setTickets(await tRes.json());
+      setAssets(await aRes.json());
+    }
+    load().catch(err => console.error('Failed to load profile', err));
+  }, [id]);
+
+  return (
+    <main className="p-4" id="main">
+      <h2 className="text-xl font-semibold mb-4">User {id}</h2>
+      <section className="mb-6">
+        <h3 className="font-semibold mb-2">Tickets</h3>
+        <ul className="list-disc pl-5">
+          {tickets.map(t => (
+            <li key={t.id}>#{t.id} - {t.question} [{t.status}]</li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h3 className="font-semibold mb-2">Assets</h3>
+        <ul className="list-disc pl-5">
+          {assets.map(a => (
+            <li key={a.id}>{a.name}</li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/server.js
+++ b/server.js
@@ -828,6 +828,23 @@ app.get("/assets/assigned/:userId", (req, res) => {
   res.json(assets);
 });
 
+// Tickets and assets for a specific user
+app.get("/users/:id/tickets", (req, res) => {
+  const uid = Number(req.params.id);
+  const user = data.users.find((u) => u.id === uid);
+  if (!user) return res.status(404).json({ error: "User not found" });
+  const tickets = data.tickets.filter((t) => t.assigneeId === uid);
+  res.json(tickets);
+});
+
+app.get("/users/:id/assets", (req, res) => {
+  const uid = Number(req.params.id);
+  const user = data.users.find((u) => u.id === uid);
+  if (!user) return res.status(404).json({ error: "User not found" });
+  const assets = (data.assets || []).filter((a) => a.assignedTo === uid);
+  res.json(assets);
+});
+
 // List all unassigned assets
 app.get("/assets/unassigned", (req, res) => {
   const assets = (data.assets || []).filter((a) => !a.assignedTo);

--- a/tests/userProfileEndpoints.test.js
+++ b/tests/userProfileEndpoints.test.js
@@ -1,0 +1,26 @@
+const http = require('http');
+const assert = require('assert');
+const app = require('../server');
+
+const server = app.listen(0, () => {
+  const port = server.address().port;
+  http.get({ port, path: '/users/1/tickets' }, res => {
+    let data = '';
+    res.on('data', c => data += c);
+    res.on('end', () => {
+      const tickets = JSON.parse(data);
+      assert.ok(Array.isArray(tickets));
+      assert.ok(tickets.every(t => t.assigneeId === 1));
+      http.get({ port, path: '/users/1/assets' }, res2 => {
+        let body = '';
+        res2.on('data', d => body += d);
+        res2.on('end', () => {
+          const assets = JSON.parse(body);
+          assert.ok(Array.isArray(assets));
+          assert.ok(assets.every(a => a.assignedTo === 1));
+          server.close(() => console.log('User profile endpoints test passed'));
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a `UserProfile` React page that loads a user's tickets and assets
- link to the new profile page in the app navigation
- provide `/users/:id/tickets` and `/users/:id/assets` API routes
- document the change in the decision log and front‑end changelog
- add tests for new endpoints

## Testing
- `npm install`
- `npm test` *(fails: Aging tickets test passed but subsequent tests didn't run)*

------
https://chatgpt.com/codex/tasks/task_e_68730ce9b6a8832b82bf67c82fb291cd