### PR TITLE
Add saved filter presets

### DIFF
--- a/frontend/src/TicketFilters.tsx
+++ b/frontend/src/TicketFilters.tsx
@@ -1,8 +1,14 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 
 export interface TicketFilter {
   status?: string;
   priority?: string;
+}
+
+interface FilterPreset {
+  id: number;
+  name: string;
+  filters: TicketFilter;
 }
 
 interface Props {
@@ -11,6 +17,57 @@ interface Props {
 }
 
 export default function TicketFilters({ filters, onChange }: Props) {
+  const [presets, setPresets] = useState<FilterPreset[]>([]);
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/filters');
+        if (res.ok) {
+          setPresets(await res.json());
+          return;
+        }
+      } catch {
+        // ignore errors and fall back to localStorage
+      }
+      const stored = localStorage.getItem('ticketFilterPresets');
+      if (stored) setPresets(JSON.parse(stored));
+    }
+    load();
+  }, []);
+
+  async function savePreset() {
+    if (!name.trim()) return;
+    const preset: FilterPreset = { id: Date.now(), name: name.trim(), filters };
+    let list = [...presets, preset];
+    setPresets(list);
+    localStorage.setItem('ticketFilterPresets', JSON.stringify(list));
+    try {
+      const res = await fetch('/filters', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: preset.name, filters }),
+      });
+      if (res.ok) {
+        const saved = await res.json();
+        preset.id = saved.id;
+        list = [...presets, preset];
+        setPresets(list);
+        localStorage.setItem('ticketFilterPresets', JSON.stringify(list));
+      }
+    } catch {
+      // ignore
+    }
+    setName('');
+  }
+
+  function applyPreset(idStr: string) {
+    const id = Number(idStr);
+    const preset = presets.find(p => p.id === id);
+    if (preset) onChange(preset.filters);
+  }
+
   function handleStatus(e: ChangeEvent<HTMLSelectElement>) {
     onChange({ ...filters, status: e.target.value || undefined });
   }
@@ -18,21 +75,40 @@ export default function TicketFilters({ filters, onChange }: Props) {
     onChange({ ...filters, priority: e.target.value || undefined });
   }
   return (
-    <div className="flex gap-2 mb-2">
-      <label htmlFor="statusFilter" className="sr-only">Status</label>
-      <select id="statusFilter" className="border p-2" value={filters.status || ''} onChange={handleStatus}>
-        <option value="">All statuses</option>
-        <option value="open">Open</option>
-        <option value="waiting">Waiting</option>
-        <option value="closed">Closed</option>
-      </select>
-      <label htmlFor="priorityFilter" className="sr-only">Priority</label>
-      <select id="priorityFilter" className="border p-2" value={filters.priority || ''} onChange={handlePriority}>
-        <option value="">All priorities</option>
-        <option value="low">Low</option>
-        <option value="medium">Medium</option>
-        <option value="high">High</option>
-      </select>
+    <div className="flex flex-col gap-2 mb-2">
+      <div className="flex gap-2">
+        <label htmlFor="statusFilter" className="sr-only">Status</label>
+        <select id="statusFilter" className="border p-2" value={filters.status || ''} onChange={handleStatus}>
+          <option value="">All statuses</option>
+          <option value="open">Open</option>
+          <option value="waiting">Waiting</option>
+          <option value="closed">Closed</option>
+        </select>
+        <label htmlFor="priorityFilter" className="sr-only">Priority</label>
+        <select id="priorityFilter" className="border p-2" value={filters.priority || ''} onChange={handlePriority}>
+          <option value="">All priorities</option>
+          <option value="low">Low</option>
+          <option value="medium">Medium</option>
+          <option value="high">High</option>
+        </select>
+      </div>
+      <div className="flex gap-2">
+        <label htmlFor="viewSelect" className="sr-only">Saved views</label>
+        <select id="viewSelect" className="border p-2" value="" onChange={e => applyPreset(e.target.value)}>
+          <option value="">Saved views</option>
+          {presets.map(p => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+        </select>
+        <input
+          aria-label="View name"
+          className="border p-2"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="New view"
+        />
+        <button className="border px-3" onClick={savePreset}>Save</button>
+      </div>
     </div>
   );
 }

--- a/server.js
+++ b/server.js
@@ -80,6 +80,9 @@ app.get("/events", (req, res) => {
 let nextTicketId = data.tickets.reduce((m, t) => Math.max(m, t.id), 0) + 1;
 let nextAssetId =
   (data.assets || []).reduce((m, a) => Math.max(m, a.id), 0) + 1;
+// store saved ticket filter presets per user
+let nextFilterId = 1;
+const filterPresets = {};
 
 // choose user with fewest open tickets
 function getLeastBusyUserId() {
@@ -1027,6 +1030,23 @@ app.post("/assets/:id/retire", (req, res) => {
     date: now,
   });
   res.json(asset);
+});
+
+// User-specific ticket filter presets
+app.get("/filters", (req, res) => {
+  const presets = filterPresets[req.user.id] || [];
+  res.json(presets);
+});
+
+app.post("/filters", (req, res) => {
+  const { name, filters } = req.body;
+  if (!name || !filters) {
+    return res.status(400).json({ error: "name and filters required" });
+  }
+  filterPresets[req.user.id] = filterPresets[req.user.id] || [];
+  const preset = { id: nextFilterId++, name, filters };
+  filterPresets[req.user.id].push(preset);
+  res.status(201).json(preset);
 });
 
 


### PR DESCRIPTION
## Summary
- allow saving ticket filter presets via `/filters` endpoint
- support storing presets from the UI in TicketFilters

## Testing
- `npm install`
- `npm test` *(fails: Aging tickets test passed before failure)*

------
https://chatgpt.com/codex/tasks/task_e_68730ce8f828832b8daaad877c8d691f