### PR TITLE
Add toast notifications and settings panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ For the long-term roadmap, see [docs/DEVELOPMENT_PLAN.md](docs/DEVELOPMENT_PLAN.
 - **Offline-capable UI** using a service worker and web app manifest.
 
 - **Real-time updates** via a Server-Sent Events endpoint.
+- **Toast notifications** for ticket events with auto-refreshing stats.
+- **Notification settings** page to opt into email or push alerts for future AI triage.
 - **Wildcard routing** using `*` to match any path.
 
 - **Stats dashboard** showing ticket counts, mean resolution time and a 7-day ticket forecast.

--- a/docs/FRONTEND_CHANGELOG.md
+++ b/docs/FRONTEND_CHANGELOG.md
@@ -43,3 +43,8 @@
 ## [2025-07-23] Service worker tweaks
 - Removed duplicate service worker registration scripts from HTML pages.
 - Cached `manifest.json` for offline support.
+
+## [2025-07-24] Toast notifications and settings page
+- Added toast container using `/events` to show ticket create/update messages.
+- Dashboard stats now refresh when events arrive.
+- Introduced a settings page for opting into email or push notifications used by future AI triage.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,10 @@
 import { BrowserRouter, Link, Route, Routes } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import Analytics from './pages/Analytics';
+import Settings from './pages/Settings';
 import ThemeToggle from './ThemeToggle';
 import CommandPalette from './components/CommandPalette';
+import ToastContainer from './components/ToastContainer';
 
 export default function App() {
   return (
@@ -12,15 +14,18 @@ export default function App() {
         <h1 className="text-2xl font-bold">AI Help Desk</h1>
         <nav>
           <Link to="/" className="mr-4 text-blue-600 hover:underline">Dashboard</Link>
-          <Link to="/analytics" className="text-blue-600 hover:underline">Analytics</Link>
+          <Link to="/analytics" className="mr-4 text-blue-600 hover:underline">Analytics</Link>
+          <Link to="/settings" className="text-blue-600 hover:underline">Settings</Link>
         </nav>
         <ThemeToggle />
       </header>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/analytics" element={<Analytics />} />
+        <Route path="/settings" element={<Settings />} />
       </Routes>
       <CommandPalette />
+      <ToastContainer />
     </BrowserRouter>
   );
 }

--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -12,17 +12,26 @@ export default function StatsPanel() {
   const [stats, setStats] = useState<DashboardStats | null>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
-  useEffect(() => {
-    async function loadStats() {
-      try {
-        const res = await fetch('/stats/dashboard');
-        const data: DashboardStats = await res.json();
-        setStats(data);
-      } catch (err) {
-        console.error('Error loading stats', err);
-      }
+  async function loadStats() {
+    try {
+      const res = await fetch('/stats/dashboard');
+      const data: DashboardStats = await res.json();
+      setStats(data);
+    } catch (err) {
+      console.error('Error loading stats', err);
     }
+  }
+
+  useEffect(() => {
     loadStats();
+  }, []);
+
+  useEffect(() => {
+    if (!window.EventSource) return;
+    const es = new EventSource('/events');
+    es.addEventListener('ticketCreated', loadStats);
+    es.addEventListener('ticketUpdated', loadStats);
+    return () => es.close();
   }, []);
 
   useEffect(() => {

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+
+interface Toast {
+  id: number;
+  message: string;
+}
+
+export default function ToastContainer() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  useEffect(() => {
+    if (!window.EventSource) return;
+    const es = new EventSource('/events');
+
+    function addToast(message: string) {
+      const id = Date.now() + Math.random();
+      setToasts(t => [...t, { id, message }]);
+      setTimeout(() => {
+        setToasts(t => t.filter(toast => toast.id !== id));
+      }, 4000);
+    }
+
+    es.addEventListener('ticketCreated', e => addToast('Ticket created: ' + e.data));
+    es.addEventListener('ticketUpdated', e => addToast('Ticket updated: ' + e.data));
+
+    return () => es.close();
+  }, []);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 space-y-2 z-50" aria-live="polite">
+      {toasts.map(t => (
+        <div key={t.id} className="bg-black text-white px-3 py-2 rounded shadow">
+          {t.message}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+export default function Settings() {
+  const [email, setEmail] = useState(() => localStorage.getItem('notifyEmail') === 'true');
+  const [push, setPush] = useState(() => localStorage.getItem('notifyPush') === 'true');
+
+  useEffect(() => {
+    localStorage.setItem('notifyEmail', email ? 'true' : 'false');
+  }, [email]);
+
+  useEffect(() => {
+    localStorage.setItem('notifyPush', push ? 'true' : 'false');
+  }, [push]);
+
+  useEffect(() => {
+    document.title = 'Settings - AI Help Desk';
+  }, []);
+
+  return (
+    <main className="p-4" id="main">
+      <h2 className="text-xl font-semibold mb-4">Notification Settings</h2>
+      <form className="space-y-2">
+        <label className="flex items-center">
+          <input type="checkbox" checked={email} onChange={() => setEmail(!email)} />
+          <span className="ml-2">Email notifications</span>
+        </label>
+        <label className="flex items-center">
+          <input type="checkbox" checked={push} onChange={() => setPush(!push)} />
+          <span className="ml-2">Push notifications</span>
+        </label>
+        <p className="text-gray-500 text-sm">Preferences used when AI triage is enabled.</p>
+      </form>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- show realtime ticket notifications via `/events`
- auto-refresh stats when events arrive
- add a settings page for email or push notification prefs
- document toast notifications and settings page in README and changelog

## Testing
- `npm install` *(installs dependencies)*
- `node run-tests.js` *(fails to finish due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68730cee9bb8832ba7ec2db70f3b5725