### PR TITLE
Add custom module typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/bcrypt": "^5.0.0",
         "@types/express": "^4.17.17",
         "@types/jsonwebtoken": "^9.0.0",
+        "@types/mssql": "^9.1.7",
         "@types/node": "^20.4.2",
         "@types/uuid": "^9.0.0",
         "prettier": "^3.0.0",
@@ -565,6 +566,18 @@
       "resolved": "https://registry.npmmirror.com/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true
+    },
+    "node_modules/@types/mssql": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/@types/mssql/-/mssql-9.1.7.tgz",
+      "integrity": "sha512-eIOEe78nuSW5KctDHImDhLZ9a+jV/z/Xs5RBhcG/jrk+YWqhdNmzBmHVWV7aWQ5fW+jbIGtX6Ph+bbVqfhzafg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "tarn": "^3.0.1",
+        "tedious": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.19.7",
@@ -4171,6 +4184,17 @@
       "resolved": "https://registry.npmmirror.com/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true
+    },
+    "@types/mssql": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/@types/mssql/-/mssql-9.1.7.tgz",
+      "integrity": "sha512-eIOEe78nuSW5KctDHImDhLZ9a+jV/z/Xs5RBhcG/jrk+YWqhdNmzBmHVWV7aWQ5fW+jbIGtX6Ph+bbVqfhzafg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "tarn": "^3.0.1",
+        "tedious": "*"
+      }
     },
     "@types/node": {
       "version": "20.19.7",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "@types/express": "^4.17.17",
     "@types/bcrypt": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.0",
-    "@types/uuid": "^9.0.0"
+    "@types/uuid": "^9.0.0",
+    "@types/mssql": "^9.1.7"
 
   }
 }

--- a/src/server/body-parser.d.ts
+++ b/src/server/body-parser.d.ts
@@ -1,0 +1,6 @@
+declare module '../../body-parser' {
+  import { json } from 'body-parser';
+  const _default: { json: typeof json };
+  export { json };
+  export default _default;
+}

--- a/src/server/express.d.ts
+++ b/src/server/express.d.ts
@@ -1,0 +1,4 @@
+declare module '../../express' {
+  import express from 'express';
+  export default express;
+}

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -9,5 +9,9 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["**/*.ts"]
+  "include": [
+    "**/*.ts",
+    "express.d.ts",
+    "body-parser.d.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- include `@types/mssql` in dev dependencies
- add `express.d.ts` and `body-parser.d.ts`
- reference new typings from server `tsconfig`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873c65484b4832bb5f9f339b881c9aa