### PR TITLE
Add Express typings for health handler

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,12 +2,13 @@ import express from '../../express';
 import bodyParser from '../../body-parser';
 import authRoutes from './routes/auth';
 import { config } from './config/environment';
+import { Request, Response } from 'express';
 
 const app = express();
 app.use(bodyParser.json());
 app.use('/auth', authRoutes);
 
-app.get('/health', (_req, res) => {
+app.get('/health', (_req: Request, res: Response) => {
   res.json({ status: 'ok' });
 });
 


### PR DESCRIPTION
## Summary
- import `Request` and `Response` types from `express`
- annotate the health endpoint handler with those types

## Testing
- `npm test` *(fails: Cannot find module 'mssql')*

------
https://chatgpt.com/codex/tasks/task_e_6873c65672fc832b8c62956571cb46d6