### PR TITLE
Fix password hash type assertion

### DIFF
--- a/src/server/services/AuthService.ts
+++ b/src/server/services/AuthService.ts
@@ -41,7 +41,10 @@ class AuthService {
       throw new Error('Account is locked');
     }
 
-    const isValid = await bcrypt.compare(credentials.password, user.Password_Hash);
+    const isValid = await bcrypt.compare(
+      credentials.password,
+      user.Password_Hash!
+    );
     if (!isValid) {
       await this.incrementFailedAttempts(user.User_ID);
       throw new Error('Invalid credentials');


### PR DESCRIPTION
## Summary
- assert `Password_Hash` after null-check in `AuthService`

## Testing
- `npm install`
- `npm test` *(fails: Aging tickets test passed, then hangs)*

------
https://chatgpt.com/codex/tasks/task_e_6873c657b018832babb03d11fba9a622