### PR TITLE
Fix public assets routing with React build

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,11 +12,10 @@ const fs = require('fs');
 const app = express();
 app.use(bodyParser.json());
 
+app.use(express.static(path.join(__dirname, 'public')));
 const reactDist = path.join(__dirname, 'frontend', 'dist');
 if (fs.existsSync(reactDist)) {
   app.use(express.static(reactDist));
-} else {
-  app.use(express.static(path.join(__dirname, 'public')));
 }
 app.use((req, res, next) => {
   res.setHeader("Access-Control-Allow-Origin", "*");
@@ -1187,11 +1186,13 @@ app.post("/ai", async (req, res) => {
   }
 });
 
-if (fs.existsSync(reactDist)) {
-  app.get('*', (req, res) => {
+app.get('*', (req, res) => {
+  if (fs.existsSync(reactDist)) {
     res.sendFile(path.join(reactDist, 'index.html'));
-  });
-}
+  } else {
+    res.sendFile(path.join(__dirname, 'public', 'index.html'));
+  }
+});
 
 const PORT = process.env.PORT || 3000;
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- always serve static files from `public/`
- only serve React `dist` if it exists
- update catch-all route to fall back to public `index.html`

## Testing
- `npm install`
- `node run-tests.js` *(fails: Aging tickets test passed then hang)*

------
https://chatgpt.com/codex/tasks/task_e_6873cf41eb00832b8e4dd35c8f20612e