### PR TITLE
Fix AuthService token expiry types

### DIFF
--- a/body-parser/index.d.ts
+++ b/body-parser/index.d.ts
@@ -1,0 +1,2 @@
+export function json(): (req: any, res: any, next: () => void) => void;
+export default { json };

--- a/express/index.d.ts
+++ b/express/index.d.ts
@@ -1,0 +1,2 @@
+import express from 'express';
+export default express;

--- a/src/server/services/AuthService.ts
+++ b/src/server/services/AuthService.ts
@@ -151,7 +151,7 @@ class AuthService {
     };
 
     const accessToken = jwt.sign(tokenPayload, config.jwt.secret, {
-      expiresIn: config.jwt.expiresIn,
+      expiresIn: config.jwt.expiresIn as jwt.SignOptions['expiresIn'],
       issuer: 'helpdesk-api',
       audience: 'helpdesk-app'
     });
@@ -160,7 +160,7 @@ class AuthService {
       { userId: user.userId, sessionId: user.sessionId },
       config.jwt.refreshSecret,
       {
-        expiresIn: config.jwt.refreshExpiresIn,
+        expiresIn: config.jwt.refreshExpiresIn as jwt.SignOptions['expiresIn'],
         issuer: 'helpdesk-api',
         audience: 'helpdesk-app'
       }

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -10,13 +10,17 @@
     "skipLibCheck": true,
     "types": [
       "node"
-    ]
+    ],
+    "paths": {
+      "../../express": ["./express.d.ts"],
+      "../../body-parser": ["./body-parser.d.ts"]
+    }
   },
   "include": [
 
     "**/*.ts",
     "express.d.ts",
-    "body-parser.d.ts"
+    "body-parser.d.ts",
 
     "../shared/**/*.ts",
     "./**/*.ts"


### PR DESCRIPTION
## Summary
- allow TypeScript to compile by declaring local express and body-parser modules
- cast JWT expiry fields when signing tokens
- fix tsconfig formatting and map paths for local modules

## Testing
- `npx tsc -p src/server`

------
https://chatgpt.com/codex/tasks/task_e_6873ecb5fcc8832b8fbcdabb21f4e975