### PR TITLE
Use path-mapped custom modules

### DIFF
--- a/src/server/body-parser.d.ts
+++ b/src/server/body-parser.d.ts
@@ -1,4 +1,4 @@
-declare module '../../body-parser' {
+declare module 'custom-body-parser' {
   import { json } from 'body-parser';
   const _default: { json: typeof json };
   export { json };

--- a/src/server/express.d.ts
+++ b/src/server/express.d.ts
@@ -1,4 +1,4 @@
-declare module '../../express' {
+declare module 'custom-express' {
   import express from 'express';
   export default express;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,5 @@
-import express from '../../express';
-import bodyParser from '../../body-parser';
+import express from 'custom-express';
+import bodyParser from 'custom-body-parser';
 import authRoutes from './routes/auth';
 import { config } from './config/environment';
 import { Request, Response } from 'express';

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -10,13 +10,17 @@
     "skipLibCheck": true,
     "types": [
       "node"
-    ]
+    ],
+    "paths": {
+      "custom-express": ["../../express"],
+      "custom-body-parser": ["../../body-parser"]
+    }
   },
   "include": [
 
     "**/*.ts",
     "express.d.ts",
-    "body-parser.d.ts"
+    "body-parser.d.ts",
 
     "../shared/**/*.ts",
     "./**/*.ts"


### PR DESCRIPTION
## Summary
- declare `custom-express` and `custom-body-parser` modules
- update server imports to use the new module names
- configure path mapping for the custom modules in `tsconfig.json`

## Testing
- `time node run-tests.js` *(fails: process hung after first test)*

------
https://chatgpt.com/codex/tasks/task_e_6873ecb4f138832bae29f4e05f0028ff