### PR TITLE
Fix TypeScript build with MSSQL types

### DIFF
--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -9,7 +9,8 @@
     "strict": true,
     "skipLibCheck": true,
     "types": [
-      "node"
+      "node",
+      "mssql"
     ],
     "paths": {
 


### PR DESCRIPTION
## Summary
- include `mssql` in server tsconfig's `types` array

## Testing
- `npm run build`
- `npm test` *(fails: could not complete due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6873f4249a54832ba736b92dc8e18373