### PR TITLE
Improve settings with accessible tabbed UI

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,8 +1,16 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export default function Settings() {
-  const [email, setEmail] = useState(() => localStorage.getItem('notifyEmail') === 'true');
-  const [push, setPush] = useState(() => localStorage.getItem('notifyPush') === 'true');
+  const [email, setEmail] = useState(
+    () => localStorage.getItem('notifyEmail') == 'true'
+  );
+  const [push, setPush] = useState(
+    () => localStorage.getItem('notifyPush') === 'true'
+  );
+  const [activeTab, setActiveTab] = useState<'notifications' | 'profile'>(
+    'notifications'
+  );
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
   useEffect(() => {
     localStorage.setItem('notifyEmail', email ? 'true' : 'false');
@@ -16,20 +24,91 @@ export default function Settings() {
     document.title = 'Settings - AI Help Desk';
   }, []);
 
+  function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    const tabs = ['notifications', 'profile'] as const;
+    const index = tabs.indexOf(activeTab);
+    if (e.key === 'ArrowRight') {
+      const next = (index + 1) % tabs.length;
+      setActiveTab(tabs[next]);
+      tabRefs.current[next]?.focus();
+      e.preventDefault();
+    } else if (e.key === 'ArrowLeft') {
+      const prev = (index - 1 + tabs.length) % tabs.length;
+      setActiveTab(tabs[prev]);
+      tabRefs.current[prev]?.focus();
+      e.preventDefault();
+    }
+  }
+
   return (
     <main className="p-4" id="main">
-      <h2 className="text-xl font-semibold mb-4">Notification Settings</h2>
-      <form className="space-y-2">
+      <div
+        className="mb-4 border-b flex space-x-4"
+        role="tablist"
+        aria-label="Settings sections"
+        onKeyDown={handleKeyDown}
+      >
+        {['notifications', 'profile'].map((id, idx) => (
+          <button
+            key={id}
+            id={`tab-${id}`}
+            role="tab"
+            ref={el => (tabRefs.current[idx] = el)}
+            aria-selected={activeTab === id}
+            aria-controls={`panel-${id}`}
+            className={`py-2 px-4 border-b-2 font-medium text-sm transition-colors ${
+              activeTab === id
+                ? 'border-blue-500 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+            }`}
+            tabIndex={activeTab === id ? 0 : -1}
+            onClick={() => setActiveTab(id as 'notifications' | 'profile')}
+          >
+            {id === 'notifications' ? 'Notifications' : 'Profile'}
+          </button>
+        ))}
+      </div>
+
+      <div
+        id="panel-notifications"
+        role="tabpanel"
+        aria-labelledby="tab-notifications"
+        hidden={activeTab !== 'notifications'}
+        className="space-y-2"
+      >
+        <h2 className="text-xl font-semibold mb-2">Notification Settings</h2>
         <label className="flex items-center">
-          <input type="checkbox" checked={email} onChange={() => setEmail(!email)} />
+          <input
+            type="checkbox"
+            checked={email}
+            onChange={() => setEmail(!email)}
+          />
           <span className="ml-2">Email notifications</span>
         </label>
         <label className="flex items-center">
-          <input type="checkbox" checked={push} onChange={() => setPush(!push)} />
+          <input
+            type="checkbox"
+            checked={push}
+            onChange={() => setPush(!push)}
+          />
           <span className="ml-2">Push notifications</span>
         </label>
-        <p className="text-gray-500 text-sm">Preferences used when AI triage is enabled.</p>
-      </form>
+        <p className="text-gray-500 text-sm">
+          Preferences used when AI triage is enabled.
+        </p>
+      </div>
+
+      <div
+        id="panel-profile"
+        role="tabpanel"
+        aria-labelledby="tab-profile"
+        hidden={activeTab !== 'profile'}
+        className="space-y-2"
+      >
+        <h2 className="text-xl font-semibold mb-2">Profile Settings</h2>
+        <p className="text-gray-500 text-sm">Profile settings coming soon.</p>
+      </div>
     </main>
   );
 }
+


### PR DESCRIPTION
## Summary
- redesign `Settings` page with a new tabbed layout
- move notification options to the first tab
- add placeholder profile tab
- implement arrow-key navigation using ARIA roles

## Testing
- `npm install`
- `timeout 60s npm test` *(tests run partially before timing out)*

------
https://chatgpt.com/codex/tasks/task_e_687467af7754832bb92d7ea2715e1250