### PR TITLE
Add bulk ticket actions with toasts

### DIFF
--- a/frontend/src/TicketTable.tsx
+++ b/frontend/src/TicketTable.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import TicketDetailPanel from "./components/TicketDetailPanel";
 import { TicketFilter } from "./TicketFilters";
+import { showToast } from "./components/toast";
 
 interface Ticket {
   id: number;
@@ -16,32 +17,34 @@ interface Props {
 export default function TicketTable({ filters }: Props) {
   const [tickets, setTickets] = useState<Ticket[]>([]);
 
-  const [sortField, setSortField] = useState<keyof Ticket>('id');
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+  const [sortField, setSortField] = useState<keyof Ticket>("id");
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [activeId, setActiveId] = useState<number | null>(null);
+  const [bulkStatus, setBulkStatus] = useState("");
+  const [bulkAssignee, setBulkAssignee] = useState("");
 
+  const loadTickets = useCallback(async () => {
+    const url = new URL("/tickets", window.location.origin);
+    if (filters.status) url.searchParams.set("status", filters.status);
+    if (filters.priority) url.searchParams.set("priority", filters.priority);
+    url.searchParams.set("sortBy", sortField);
+    url.searchParams.set("order", sortOrder);
+    const res = await fetch(url.toString());
+    const data = await res.json();
+    setTickets(data);
+  }, [filters, sortField, sortOrder]);
 
   useEffect(() => {
-    async function load() {
-      const url = new URL("/tickets", window.location.origin);
-      if (filters.status) url.searchParams.set("status", filters.status);
-      if (filters.priority) url.searchParams.set("priority", filters.priority);
-      url.searchParams.set("sortBy", sortField);
-      url.searchParams.set("order", sortOrder);
-      const res = await fetch(url.toString());
-      const data = await res.json();
-      setTickets(data);
-    }
-    load().catch((err) => console.error("Error loading tickets", err));
+    loadTickets().catch((err) => console.error("Error loading tickets", err));
 
     if (window.EventSource) {
       const es = new EventSource("/events");
-      es.addEventListener("ticketCreated", load);
-      es.addEventListener("ticketUpdated", load);
+      es.addEventListener("ticketCreated", loadTickets);
+      es.addEventListener("ticketUpdated", loadTickets);
       return () => es.close();
     }
-  }, [filters, sortField, sortOrder]);
+  }, [loadTickets]);
 
   function toggleSort(field: keyof Ticket) {
     if (sortField === field) {
@@ -53,7 +56,7 @@ export default function TicketTable({ filters }: Props) {
   }
 
   function toggleSelect(id: number) {
-    setSelected(s => {
+    setSelected((s) => {
       const copy = new Set(s);
       if (copy.has(id)) {
         copy.delete(id);
@@ -64,64 +67,146 @@ export default function TicketTable({ filters }: Props) {
     });
   }
 
-  const allSelected = tickets.length > 0 && tickets.every(t => selected.has(t.id));
+  const allSelected =
+    tickets.length > 0 && tickets.every((t) => selected.has(t.id));
 
   function toggleSelectAll(checked: boolean) {
-    setSelected(s => {
+    setSelected((s) => {
       const copy = new Set(s);
       if (checked) {
-        tickets.forEach(t => copy.add(t.id));
+        tickets.forEach((t) => copy.add(t.id));
       } else {
-        tickets.forEach(t => copy.delete(t.id));
+        tickets.forEach((t) => copy.delete(t.id));
       }
       return copy;
     });
   }
 
-  return (
+  async function applyBulkStatus() {
+    if (!bulkStatus) return;
+    const res = await fetch("/tickets/bulk-update", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ids: Array.from(selected), status: bulkStatus }),
+    });
+    if (res.ok) {
+      showToast("Updated tickets");
+      setSelected(new Set());
+      setBulkStatus("");
+      await loadTickets();
+    } else {
+      showToast("Failed to update tickets");
+    }
+  }
 
+  async function applyBulkAssign() {
+    if (!bulkAssignee) return;
+    const res = await fetch("/tickets/bulk-assign", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ids: Array.from(selected),
+        assigneeId: Number(bulkAssignee),
+      }),
+    });
+    if (res.ok) {
+      showToast("Assigned tickets");
+      setSelected(new Set());
+      setBulkAssignee("");
+      await loadTickets();
+    } else {
+      showToast("Failed to assign tickets");
+    }
+  }
+
+  return (
     <div className="relative" onMouseLeave={() => setActiveId(null)}>
-   
-    <table className="table-auto border-collapse" style={{ width: '100%' }}>
-      <thead>
-        <tr>
-          <th>
-            <input
-              type="checkbox"
-              checked={allSelected}
-              onChange={e => toggleSelectAll(e.target.checked)}
-            />
-          </th>
-          <th onClick={() => toggleSort('id')} style={{ cursor: 'pointer' }}>ID</th>
-          <th onClick={() => toggleSort('question')} style={{ cursor: 'pointer' }}>Question</th>
-          <th onClick={() => toggleSort('status')} style={{ cursor: 'pointer' }}>Status</th>
-          <th onClick={() => toggleSort('priority')} style={{ cursor: 'pointer' }}>Priority</th>
-        </tr>
-      </thead>
-      <tbody>
-        {tickets.map(t => (
-          <tr
-            key={t.id}
-            onMouseEnter={() => setActiveId(t.id)}
-            onFocus={() => setActiveId(t.id)}
-            onClick={() => setActiveId(t.id)}
-            tabIndex={0}
-            className="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700"
+      {selected.size > 0 && (
+        <div className="absolute top-0 left-0 right-0 bg-gray-200 dark:bg-gray-800 border-b p-2 flex flex-wrap gap-2 items-center">
+          <span>{selected.size} selected</span>
+          <select
+            className="border p-1"
+            value={bulkStatus}
+            onChange={(e) => setBulkStatus(e.target.value)}
           >
-            <td>
+            <option value="">Status...</option>
+            <option value="open">Open</option>
+            <option value="waiting">Waiting</option>
+            <option value="closed">Closed</option>
+          </select>
+          <button className="border px-2" onClick={applyBulkStatus}>
+            Update
+          </button>
+          <input
+            className="border p-1"
+            placeholder="Assignee ID"
+            type="number"
+            value={bulkAssignee}
+            onChange={(e) => setBulkAssignee(e.target.value)}
+          />
+          <button className="border px-2" onClick={applyBulkAssign}>
+            Assign
+          </button>
+        </div>
+      )}
+
+      <table className="table-auto border-collapse" style={{ width: "100%" }}>
+        <thead>
+          <tr>
+            <th>
               <input
                 type="checkbox"
-                checked={selected.has(t.id)}
-                onChange={() => toggleSelect(t.id)}
+                checked={allSelected}
+                onChange={(e) => toggleSelectAll(e.target.checked)}
               />
-            </td>
-            <td>{t.id}</td>
-            <td>{t.question}</td>
-            <td>{t.status}</td>
-            <td>{t.priority}</td>
+            </th>
+            <th onClick={() => toggleSort("id")} style={{ cursor: "pointer" }}>
+              ID
+            </th>
+            <th
+              onClick={() => toggleSort("question")}
+              style={{ cursor: "pointer" }}
+            >
+              Question
+            </th>
+            <th
+              onClick={() => toggleSort("status")}
+              style={{ cursor: "pointer" }}
+            >
+              Status
+            </th>
+            <th
+              onClick={() => toggleSort("priority")}
+              style={{ cursor: "pointer" }}
+            >
+              Priority
+            </th>
           </tr>
-        ))}
-      </tbody>
+        </thead>
+        <tbody>
+          {tickets.map((t) => (
+            <tr
+              key={t.id}
+              onMouseEnter={() => setActiveId(t.id)}
+              onFocus={() => setActiveId(t.id)}
+              onClick={() => setActiveId(t.id)}
+              tabIndex={0}
+              className="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              <td>
+                <input
+                  type="checkbox"
+                  checked={selected.has(t.id)}
+                  onChange={() => toggleSelect(t.id)}
+                />
+              </td>
+              <td>{t.id}</td>
+              <td>{t.question}</td>
+              <td>{t.status}</td>
+              <td>{t.priority}</td>
+            </tr>
+          ))}
+        </tbody>
       </table>
       <TicketDetailPanel
         ticketId={activeId}

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
 
 interface Toast {
   id: number;
@@ -9,29 +9,48 @@ export default function ToastContainer() {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
   useEffect(() => {
-    if (!window.EventSource) return;
-    const es = new EventSource('/events');
-
     function addToast(message: string) {
       const id = Date.now() + Math.random();
-      setToasts(t => [...t, { id, message }]);
+      setToasts((t) => [...t, { id, message }]);
       setTimeout(() => {
-        setToasts(t => t.filter(toast => toast.id !== id));
+        setToasts((t) => t.filter((toast) => toast.id !== id));
       }, 4000);
     }
 
-    es.addEventListener('ticketCreated', e => addToast('Ticket created: ' + e.data));
-    es.addEventListener('ticketUpdated', e => addToast('Ticket updated: ' + e.data));
+    const cleanup: (() => void)[] = [];
 
-    return () => es.close();
+    const toastHandler = (e: Event) => {
+      const msg = (e as CustomEvent<string>).detail;
+      if (msg) addToast(msg);
+    };
+    window.addEventListener("toast", toastHandler);
+    cleanup.push(() => window.removeEventListener("toast", toastHandler));
+
+    let es: EventSource | null = null;
+    if (window.EventSource) {
+      es = new EventSource("/events");
+      es.addEventListener("ticketCreated", (e) =>
+        addToast("Ticket created: " + (e as MessageEvent).data),
+      );
+      es.addEventListener("ticketUpdated", (e) =>
+        addToast("Ticket updated: " + (e as MessageEvent).data),
+      );
+      cleanup.push(() => es && es.close());
+    }
+    return () => {
+      cleanup.forEach((fn) => fn());
+    };
   }, []);
 
   if (toasts.length === 0) return null;
 
   return (
     <div className="fixed bottom-4 right-4 space-y-2 z-50" aria-live="polite">
-      {toasts.map(t => (
-        <div key={t.id} className="bg-black text-white px-3 py-2 rounded shadow">
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          className="bg-black text-white px-3 py-2 rounded shadow"
+        >
           {t.message}
         </div>
       ))}

--- a/frontend/src/components/toast.ts
+++ b/frontend/src/components/toast.ts
@@ -1,0 +1,3 @@
+export function showToast(message: string) {
+  window.dispatchEvent(new CustomEvent("toast", { detail: message }));
+}


### PR DESCRIPTION
## Summary
- show custom toasts using a `toast` event
- expose `showToast` helper
- add bulk update and assign actions in `TicketTable`

## Testing
- `npm test` *(fails: Aging tickets test passed but suite did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_687467affdac832b917293aa88370390