### PR TITLE
Add class-based dark mode with OS fallback

### DIFF
--- a/frontend/src/ThemeToggle.tsx
+++ b/frontend/src/ThemeToggle.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useState } from 'react';
 
 export default function ThemeToggle() {
-  const [theme, setTheme] = useState<'light' | 'dark'>(() =>
-    (localStorage.getItem('theme') as 'light' | 'dark') || 'light'
-  );
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    const stored = localStorage.getItem('theme') as 'light' | 'dark' | null;
+    if (stored) return stored;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+  });
 
   useEffect(() => {
     document.body.classList.toggle('dark', theme === 'dark');

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply transition-colors duration-300;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   content: [
     './index.html',
     './src/**/*.{ts,tsx}',


### PR DESCRIPTION
## Summary
- enable `darkMode: 'class'` in Tailwind
- detect OS preference when theme not stored
- animate color changes when toggling theme
- rebuild the frontend assets

## Testing
- `npm run build` in `frontend`
- `npm test` *(fails: Aging tickets test passed then hangs)*

------
https://chatgpt.com/codex/tasks/task_e_687467af23e8832ba28bd46f032be7b7