### PR TITLE
Escape HTML in comments and add test

### DIFF
--- a/server.js
+++ b/server.js
@@ -509,8 +509,14 @@ app.delete("/tickets/:id/attachments/:attachmentId", (req, res) => {
 function parseMentions(text) {
   const regex = /@([a-zA-Z0-9_]+)/g;
   const mentions = [];
-  const highlighted = text.replace(regex, (m, name) => {
-    const user = data.users.find((u) => u.name.toLowerCase() === name.toLowerCase());
+  const escaped = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  const highlighted = escaped.replace(regex, (m, name) => {
+    const user = data.users.find(
+      (u) => u.name.toLowerCase() === name.toLowerCase(),
+    );
     if (user) mentions.push(user.id);
     return `<mark>@${name}</mark>`;
   });

--- a/tests/commentHtmlEscaping.test.js
+++ b/tests/commentHtmlEscaping.test.js
@@ -1,0 +1,30 @@
+const http = require('http');
+const assert = require('assert');
+const app = require('../server');
+
+const server = app.listen(0, () => {
+  const port = server.address().port;
+  const tid = 2353;
+  const text = "<script>alert('x')</script> hello @Alice";
+  const add = http.request(
+    { port, path: `/tickets/${tid}/comments`, method: 'POST', headers: { 'Content-Type': 'application/json' } },
+    res => {
+      let body = '';
+      res.on('data', d => body += d);
+      res.on('end', () => {
+        const comment = JSON.parse(body);
+        http.get({ port, path: `/tickets/${tid}/comments/${comment.id}` }, gres => {
+          let data = '';
+          gres.on('data', c => data += c);
+          gres.on('end', () => {
+            const fetched = JSON.parse(data);
+            assert.ok(fetched.html.includes('&lt;script&gt;alert('));
+            assert.ok(!fetched.html.includes('<script>'));
+            server.close(() => console.log('Comment HTML escaping test passed'));
+          });
+        });
+      });
+    }
+  );
+  add.end(JSON.stringify({ text }));
+});


### PR DESCRIPTION
## Summary
- sanitize `<`, `>`, and `&` in `parseMentions`
- ensure comments store escaped HTML
- regression test for HTML escaping in comments

## Testing
- `node tests/commentHtmlEscaping.test.js`
- `node tests/agingTickets.test.js`
- `node run-tests.js` *(fails: process hangs after first test)*

------
https://chatgpt.com/codex/tasks/task_e_68758ea065ac832b90e57194796ab080