### PR TITLE
Implement token based auth middleware

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -8,7 +8,10 @@ async function run() {
     .sort();
   for (const file of tests) {
     await new Promise((resolve, reject) => {
-      const child = fork(path.join(__dirname, 'tests', file), { stdio: 'inherit' });
+      const child = fork(path.join(__dirname, 'tests', file), {
+        stdio: 'inherit',
+        execArgv: ['-r', path.join(__dirname, 'tests', 'authHeader.js')],
+      });
       child.on('exit', code => {
         if (code !== 0) {
           reject(new Error(`${file} failed`));

--- a/server.js
+++ b/server.js
@@ -99,9 +99,21 @@ function getLeastBusyUserId() {
   return chosen.id;
 }
 
-// Middleware to simulate authentication
+// Authentication middleware
 app.use((req, res, next) => {
-  req.user = data.users[0];
+  const authHeader = req.headers.authorization;
+  const token = authHeader && authHeader.split(' ')[1];
+  const payload = token && auth.verifyToken(token);
+  if (!payload) {
+    res.status(401).json({ error: 'Invalid token' });
+    return;
+  }
+  const user = data.users.find((u) => u.id === payload.id);
+  if (!user) {
+    res.status(401).json({ error: 'Invalid token' });
+    return;
+  }
+  req.user = user;
   next();
 });
 

--- a/tests/authHeader.js
+++ b/tests/authHeader.js
@@ -1,0 +1,19 @@
+const http = require('http');
+const auth = require('../utils/authService');
+
+const { token } = auth.authenticate('Brian', 'password1');
+const authHeader = { Authorization: `Bearer ${token}` };
+
+function wrap(fn) {
+  return function (options, ...args) {
+    if (typeof options === 'string') options = new URL(options);
+    else options = { ...options };
+    options.headers = { ...authHeader, ...(options.headers || {}) };
+    return fn.call(http, options, ...args);
+  };
+}
+
+http.request = wrap(http.request);
+http.get = wrap(http.get);
+
+module.exports = { token, authHeader };


### PR DESCRIPTION
## Summary
- replace placeholder auth with JWT-based middleware
- automatically add auth header to test requests via `authHeader.js`
- load helper in all tests via run-tests.js

## Testing
- `node --require ./tests/authHeader.js tests/agingTickets.test.js`
- `node --require ./tests/authHeader.js tests/assetDelete.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68758ea169b0832bb7337c9541eae0ff