### PR TITLE
Add analytics utilities and refactor stats routes

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const data = require("./data/mockData");
 const dataService = require("./utils/dataService");
 const auth = require("./utils/authService");
 const eventBus = require("./utils/eventBus");
+const analytics = require("./utils/analyticsEngine");
 
 const fs = require('fs');
 const app = express();
@@ -702,79 +703,21 @@ app.get("/stats", (req, res) => {
 
 // Consolidated stats for dashboard UI
 app.get("/stats/dashboard", (req, res) => {
-  const tickets = {
-    open: data.tickets.filter((t) => t.status === "open").length,
-    waiting: data.tickets.filter((t) => t.status === "waiting").length,
-    closed: data.tickets.filter((t) => t.status === "closed").length,
-  };
-
-  const counts = {};
-  data.tickets.forEach((t) => {
-    const created = (t.history || []).find((h) => h.action === "created");
-    if (!created) return;
-    const d = new Date(created.date).toISOString().slice(0, 10);
-    counts[d] = (counts[d] || 0) + 1;
-  });
-  const total = Object.values(counts).reduce((sum, c) => sum + c, 0);
-  const avgDaily = Object.keys(counts).length
-    ? total / Object.keys(counts).length
-    : 0;
-
-  const durations = data.tickets
-    .filter((t) => t.status === "closed")
-    .map((t) => {
-      const created = (t.history || []).find((h) => h.action === "created");
-      const closed = (t.history || []).find(
-        (h) => h.action === "status" && h.to === "closed",
-      );
-      if (!created || !closed) return null;
-      return new Date(closed.date).getTime() - new Date(created.date).getTime();
-    })
-    .filter((d) => d !== null);
-  const avgMs = durations.length
-    ? durations.reduce((sum, d) => sum + d, 0) / durations.length
-    : 0;
-
-  res.json({
-    tickets,
-    forecast: avgDaily * 7,
-    mttr: avgMs / 3600000,
-    assets: { total: (data.assets || []).length },
-  });
+  const insights = analytics.generateInsights(data.tickets, data.assets || []);
+  res.json(insights);
 });
 
 // Mean Time To Resolution in hours
 app.get("/stats/mttr", (req, res) => {
-  const durations = data.tickets
-    .filter((t) => t.status === "closed")
-    .map((t) => {
-      const created = (t.history || []).find((h) => h.action === "created");
-      const closed = (t.history || []).find(
-        (h) => h.action === "status" && h.to === "closed",
-      );
-      if (!created || !closed) return null;
-      return new Date(closed.date).getTime() - new Date(created.date).getTime();
-    })
-    .filter((d) => d !== null);
-  const avg = durations.length
-    ? durations.reduce((sum, d) => sum + d, 0) / durations.length
-    : 0;
-  res.json({ mttr: avg / 3600000 });
+  const mttr = analytics.calculateMTTR(data.tickets);
+  res.json({ mttr });
 });
 
 // Predict ticket creation volume for the next N days (default 7)
 app.get("/stats/forecast", (req, res) => {
   const days = Number(req.query.days) || 7;
-  const counts = {};
-  data.tickets.forEach((t) => {
-    const created = (t.history || []).find((h) => h.action === "created");
-    if (!created) return;
-    const d = new Date(created.date).toISOString().slice(0, 10);
-    counts[d] = (counts[d] || 0) + 1;
-  });
-  const total = Object.values(counts).reduce((sum, c) => sum + c, 0);
-  const avg = Object.keys(counts).length ? total / Object.keys(counts).length : 0;
-  res.json({ forecast: avg * days });
+  const forecast = analytics.predictTicketVolume(data.tickets, days);
+  res.json({ forecast });
 });
 
 // Ticket counts per user by status

--- a/tests/analyticsEngine.test.js
+++ b/tests/analyticsEngine.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { calculateMTTR, predictTicketVolume, generateInsights } = require('../utils/analyticsEngine');
+const mock = require('../data/mockData');
+
+const mttr = calculateMTTR(mock.tickets);
+assert.ok(typeof mttr === 'number');
+assert.ok(mttr >= 0);
+
+const forecast = predictTicketVolume(mock.tickets, 5);
+assert.ok(typeof forecast === 'number');
+assert.ok(forecast >= 0);
+
+const insights = generateInsights(mock.tickets, mock.assets);
+assert.ok(insights.tickets.open >= 0);
+assert.ok(typeof insights.forecast === 'number');
+assert.ok(typeof insights.mttr === 'number');
+
+console.log('Analytics engine tests passed');

--- a/utils/analyticsEngine.js
+++ b/utils/analyticsEngine.js
@@ -1,0 +1,44 @@
+function calculateMTTR(tickets) {
+  const durations = (tickets || [])
+    .filter(t => t.status === 'closed')
+    .map(t => {
+      const created = (t.history || []).find(h => h.action === 'created');
+      const closed = (t.history || []).find(h => h.action === 'status' && h.to === 'closed');
+      if (!created || !closed) return null;
+      return new Date(closed.date).getTime() - new Date(created.date).getTime();
+    })
+    .filter(d => d !== null);
+  if (!durations.length) return 0;
+  const avg = durations.reduce((sum, d) => sum + d, 0) / durations.length;
+  return avg / 3600000; // hours
+}
+
+function predictTicketVolume(tickets, days = 7) {
+  const counts = {};
+  (tickets || []).forEach(t => {
+    const created = (t.history || []).find(h => h.action === 'created');
+    if (!created) return;
+    const d = new Date(created.date).toISOString().slice(0, 10);
+    counts[d] = (counts[d] || 0) + 1;
+  });
+  const total = Object.values(counts).reduce((sum, c) => sum + c, 0);
+  const avg = Object.keys(counts).length ? total / Object.keys(counts).length : 0;
+  return avg * days;
+}
+
+function generateInsights(tickets, assets = []) {
+  const ticketStats = {
+    open: (tickets || []).filter(t => t.status === 'open').length,
+    waiting: (tickets || []).filter(t => t.status === 'waiting').length,
+    closed: (tickets || []).filter(t => t.status === 'closed').length,
+  };
+
+  return {
+    tickets: ticketStats,
+    forecast: predictTicketVolume(tickets, 7),
+    mttr: calculateMTTR(tickets),
+    assets: { total: assets.length },
+  };
+}
+
+module.exports = { calculateMTTR, predictTicketVolume, generateInsights };


### PR DESCRIPTION
## Summary
- add `analyticsEngine` utilities for MTTR, ticket volume prediction and insights
- refactor stats routes to use analytics utilities
- unit test analytics functions

## Testing
- `npm test` *(fails: tests hang after some output)*

------
https://chatgpt.com/codex/tasks/task_e_68758ea2a244832b895e9b5b848e67a1