### PR TITLE
Implement Phase 3 analytics endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -794,6 +794,33 @@ app.get("/stats/workload", (req, res) => {
   res.json(workload);
 });
 
+// Ticket volume trends for the last N days with simple anomaly detection
+app.get("/stats/trends", (req, res) => {
+  const days = Number(req.query.days) || 30;
+  const now = new Date();
+  const counts = {};
+  data.tickets.forEach((t) => {
+    const created = (t.history || []).find((h) => h.action === "created");
+    if (!created) return;
+    const d = new Date(created.date);
+    const diff = Math.floor((now.getTime() - d.getTime()) / 86400000);
+    if (diff < days) {
+      const key = d.toISOString().slice(0, 10);
+      counts[key] = (counts[key] || 0) + 1;
+    }
+  });
+  const series = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(now.getTime() - i * 86400000)
+      .toISOString()
+      .slice(0, 10);
+    series.push({ date: d, tickets: counts[d] || 0 });
+  }
+  const avg = series.reduce((s, r) => s + r.tickets, 0) / days;
+  const anomalies = series.filter((r) => r.tickets > avg * 1.5).map((r) => r.date);
+  res.json({ series, forecast: avg * days, anomalies });
+});
+
 // Ticket counts per priority across all tickets
 app.get("/stats/priorities", (req, res) => {
   const counts = {};
@@ -1184,6 +1211,14 @@ app.post("/ai", async (req, res) => {
     console.error(err);
     res.status(500).json({ error: "Failed to process text" });
   }
+});
+
+// Basic sentiment analysis for a text string
+app.post("/ai/sentiment", (req, res) => {
+  const { text } = req.body;
+  if (!text) return res.status(400).json({ error: "text required" });
+  const sentiment = aiService.analyzeSentiment(text);
+  res.json({ sentiment });
 });
 
 app.get('*', (req, res) => {

--- a/tests/sentimentAnalysis.test.js
+++ b/tests/sentimentAnalysis.test.js
@@ -1,0 +1,17 @@
+const http = require('http');
+const assert = require('assert');
+const app = require('../server');
+
+const server = app.listen(0, () => {
+  const port = server.address().port;
+  const req = http.request({ port, path: '/ai/sentiment', method: 'POST', headers: { 'Content-Type': 'application/json' } }, res => {
+    let data = '';
+    res.on('data', d => data += d);
+    res.on('end', () => {
+      const obj = JSON.parse(data);
+      assert.ok(obj.sentiment);
+      server.close(() => console.log('Sentiment analysis test passed'));
+    });
+  });
+  req.end(JSON.stringify({ text: 'I love this product!' }));
+});

--- a/tests/trendsEndpoint.test.js
+++ b/tests/trendsEndpoint.test.js
@@ -1,0 +1,19 @@
+const http = require('http');
+const assert = require('assert');
+const app = require('../server');
+
+const server = app.listen(0, () => {
+  const port = server.address().port;
+  http.get({ port, path: '/stats/trends?days=5' }, res => {
+    let data = '';
+    res.on('data', d => data += d);
+    res.on('end', () => {
+      const obj = JSON.parse(data);
+      assert.ok(Array.isArray(obj.series));
+      assert.ok(obj.series.length === 5);
+      assert.ok(typeof obj.forecast === 'number');
+      assert.ok(Array.isArray(obj.anomalies));
+      server.close(() => console.log('Trends endpoint test passed'));
+    });
+  });
+});

--- a/utils/aiService.js
+++ b/utils/aiService.js
@@ -9,4 +9,36 @@ function categorizeTicket(text) {
   return "general";
 }
 
-module.exports = { categorizeTicket };
+function analyzeSentiment(text) {
+  text = text.toLowerCase();
+  const positiveWords = [
+    'good',
+    'great',
+    'excellent',
+    'love',
+    'awesome',
+    'thank',
+    'thanks',
+  ];
+  const negativeWords = [
+    'bad',
+    'terrible',
+    'awful',
+    'hate',
+    'slow',
+    'broken',
+    'error',
+  ];
+  let score = 0;
+  positiveWords.forEach((w) => {
+    if (text.includes(w)) score++;
+  });
+  negativeWords.forEach((w) => {
+    if (text.includes(w)) score--;
+  });
+  if (score > 0) return 'positive';
+  if (score < 0) return 'negative';
+  return 'neutral';
+}
+
+module.exports = { categorizeTicket, analyzeSentiment };


### PR DESCRIPTION
## Summary
- add sentiment analysis helper
- expose `/ai/sentiment` endpoint
- add `/stats/trends` with anomaly detection
- test sentiment analysis and trends endpoints

## Testing
- `npm install`
- `npm test` *(fails: `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`)*

------
https://chatgpt.com/codex/tasks/task_e_68758a6b6d20832b834b6627dee00b73