### PR TITLE
Implement virtualization and lazy loaded widgets

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,9 @@
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.21.0"
+        "react-router-dom": "^6.21.0",
+        "react-swipeable": "^7.0.0",
+        "react-window": "^1.8.7"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.0.0",
@@ -2029,6 +2031,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3099,6 +3107,32 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-cache": {
@@ -5060,6 +5094,11 @@
         "yallist": "^3.0.2"
       }
     },
+    "memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5710,6 +5749,21 @@
       "requires": {
         "@remix-run/router": "1.23.0",
         "react-router": "6.30.1"
+      }
+    },
+    "react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "requires": {}
+    },
+    "react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
       }
     },
     "read-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,9 @@
     "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.21.0"
+    "react-router-dom": "^6.21.0",
+    "react-window": "^1.8.7",
+    "react-swipeable": "^7.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,22 +1,22 @@
 import { BrowserRouter, Route, Routes, Link } from 'react-router-dom';
 import { ConfigProvider } from 'antd';
-import Dashboard from './pages/Dashboard';
-import Analytics from './pages/Analytics';
-import Settings from './pages/Settings';
+import { lazy, Suspense } from 'react';
 import ToastContainer from './components/ToastContainer';
-import UserProfile from './pages/UserProfile';
 import ThemeToggle from './ThemeToggle';
 import CommandPalette from './components/CommandPalette';
 import Sidebar from './components/Sidebar';
 import { useTheme } from './hooks/useTheme';
 
+const Dashboard = lazy(() => import('./pages/Dashboard'));
+const Analytics = lazy(() => import('./pages/Analytics'));
+const Settings = lazy(() => import('./pages/Settings'));
+const UserProfile = lazy(() => import('./pages/UserProfile'));
+
 export default function App() {
   const { algorithm } = useTheme();
   return (
-
     <ConfigProvider theme={{ algorithm }}>
-     
-    <BrowserRouter>
+      <BrowserRouter>
       <a href="#main" className="skip-link">Skip to content</a>
       <header className="flex justify-between items-center py-4">
 
@@ -37,18 +37,17 @@ export default function App() {
         </nav>
         <ThemeToggle />
       </header>
-      <Routes>
-        <Route path="/" element={<Dashboard />} />
-        <Route path="/analytics" element={<Analytics />} />
-
-        <Route path="/settings" element={<Settings />} />
-
-        <Route path="/users/:id" element={<UserProfile />} />
-
-      </Routes>
+      <Suspense fallback={<p>Loading...</p>}>
+        <Routes>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/analytics" element={<Analytics />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="/users/:id" element={<UserProfile />} />
+        </Routes>
+      </Suspense>
       <CommandPalette />
       <ToastContainer />
-    </BrowserRouter>
-
+      </BrowserRouter>
+    </ConfigProvider>
   );
 }

--- a/frontend/src/TicketFilters.tsx
+++ b/frontend/src/TicketFilters.tsx
@@ -116,7 +116,7 @@ export default function TicketFilters({ filters, onChange }: Props) {
           placeholder="New view"
           style={{ width: 160 }}
         />
-        <Button onClick={savePreset}>Save</Button>
+        <Button onClick={savePreset} className="touch-target">Save</Button>
       </div>
     </div>
   );

--- a/frontend/src/TicketTable.tsx
+++ b/frontend/src/TicketTable.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useState, useCallback } from 'react';
-import { Table, Select, Button, Input } from 'antd';
+import { useCallback, useEffect, useState } from 'react';
+import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
+import { useSwipeable } from 'react-swipeable';
+import { Select, Button, Input } from 'antd';
 import TicketDetailPanel from './components/TicketDetailPanel';
 import { TicketFilter } from './TicketFilters';
 import { showToast } from './components/toast';
@@ -13,18 +15,22 @@ interface Ticket {
 
 interface Props {
   filters: TicketFilter;
+  tickets?: Ticket[];
 }
 
-export default function TicketTable({ filters }: Props) {
-  const [tickets, setTickets] = useState<Ticket[]>([]);
+const ROW_HEIGHT = 56;
+
+export default function TicketTable({ filters, tickets: initial }: Props) {
+  const [tickets, setTickets] = useState<Ticket[]>(initial || []);
   const [sortField, setSortField] = useState<keyof Ticket>('id');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
-  const [selected, setSelected] = useState<React.Key[]>([]);
+  const [selected, setSelected] = useState<number[]>([]);
   const [activeId, setActiveId] = useState<number | null>(null);
   const [bulkStatus, setBulkStatus] = useState('');
   const [bulkAssignee, setBulkAssignee] = useState('');
 
   const loadTickets = useCallback(async () => {
+    if (initial) return;
     const url = new URL('/tickets', window.location.origin);
     if (filters.status) url.searchParams.set('status', filters.status);
     if (filters.priority) url.searchParams.set('priority', filters.priority);
@@ -33,17 +39,33 @@ export default function TicketTable({ filters }: Props) {
     const res = await fetch(url.toString());
     const data = await res.json();
     setTickets(data);
-  }, [filters, sortField, sortOrder]);
+  }, [filters, sortField, sortOrder, initial]);
 
   useEffect(() => {
     loadTickets().catch(err => console.error('Error loading tickets', err));
-    if (window.EventSource) {
+    if (!initial && window.EventSource) {
       const es = new EventSource('/events');
       es.addEventListener('ticketCreated', loadTickets);
       es.addEventListener('ticketUpdated', loadTickets);
       return () => es.close();
     }
-  }, [loadTickets]);
+  }, [loadTickets, initial]);
+
+  async function closeTicket(id: number) {
+    const res = await fetch(`/tickets/${id}/close`, { method: 'POST' });
+    if (res.ok) {
+      showToast('Ticket closed');
+      await loadTickets();
+    }
+  }
+
+  async function assignTicket(id: number) {
+    const res = await fetch(`/tickets/${id}/assign/1`, { method: 'POST' });
+    if (res.ok) {
+      showToast('Ticket assigned');
+      await loadTickets();
+    }
+  }
 
   async function applyBulkStatus() {
     if (!bulkStatus) return;
@@ -79,29 +101,58 @@ export default function TicketTable({ filters }: Props) {
     }
   }
 
-  const columns = [
-    { title: 'ID', dataIndex: 'id', sorter: true },
-    { title: 'Question', dataIndex: 'question', sorter: true },
-    { title: 'Status', dataIndex: 'status', sorter: true },
-    { title: 'Priority', dataIndex: 'priority', sorter: true },
-  ];
+  const sorted = [...tickets].sort((a, b) => {
+    const x = a[sortField];
+    const y = b[sortField];
+    if (x < y) return sortOrder === 'asc' ? -1 : 1;
+    if (x > y) return sortOrder === 'asc' ? 1 : -1;
+    return 0;
+  });
+
+  function toggleSelect(id: number, on: boolean) {
+    setSelected(prev => (on ? [...prev, id] : prev.filter(i => i !== id)));
+  }
+
+  const Row = ({ index, style }: ListChildComponentProps) => {
+    const t = sorted[index];
+    const handlers = useSwipeable({
+      onSwipedLeft: () => closeTicket(t.id),
+      onSwipedRight: () => assignTicket(t.id),
+    });
+    return (
+      <div
+        {...handlers}
+        style={style}
+        className="grid grid-cols-[40px_60px_1fr_120px_120px] items-center border-b px-2"
+        onMouseEnter={() => setActiveId(t.id)}
+        onClick={() => setActiveId(t.id)}
+      >
+        <input
+          type="checkbox"
+          checked={selected.includes(t.id)}
+          onChange={e => toggleSelect(t.id, e.target.checked)}
+          className="mr-2"
+        />
+        <div>{t.id}</div>
+        <div className="truncate">{t.question}</div>
+        <div>{t.status}</div>
+        <div>{t.priority}</div>
+      </div>
+    );
+  };
 
   return (
     <div className="relative" onMouseLeave={() => setActiveId(null)}>
       {selected.length > 0 && (
         <div className="absolute top-0 left-0 right-0 bg-gray-200 dark:bg-gray-800 border-b p-2 flex flex-wrap gap-2 items-center z-10">
           <span>{selected.length} selected</span>
-          <Select
-            value={bulkStatus}
-            onChange={setBulkStatus}
-            style={{ width: 120 }}
-          >
+          <Select value={bulkStatus} onChange={setBulkStatus} style={{ width: 120 }}>
             <Select.Option value="">Status...</Select.Option>
             <Select.Option value="open">Open</Select.Option>
             <Select.Option value="waiting">Waiting</Select.Option>
             <Select.Option value="closed">Closed</Select.Option>
           </Select>
-          <Button onClick={applyBulkStatus}>Update</Button>
+          <Button onClick={applyBulkStatus} className="touch-target">Update</Button>
           <Input
             placeholder="Assignee ID"
             type="number"
@@ -109,28 +160,19 @@ export default function TicketTable({ filters }: Props) {
             onChange={e => setBulkAssignee(e.target.value)}
             style={{ width: 120 }}
           />
-          <Button onClick={applyBulkAssign}>Assign</Button>
+          <Button onClick={applyBulkAssign} className="touch-target">Assign</Button>
         </div>
       )}
-
-      <Table
-        rowKey="id"
-        dataSource={tickets}
-        columns={columns}
-        pagination={false}
-        rowSelection={{ selectedRowKeys: selected, onChange: keys => setSelected(keys) }}
-        onChange={(pagination, filters, sorter) => {
-          const s = sorter as any;
-          if (s.field) {
-            setSortField(s.field);
-            setSortOrder(s.order === 'ascend' ? 'asc' : 'desc');
-          }
-        }}
-        onRow={record => ({
-          onMouseEnter: () => setActiveId(record.id),
-          onClick: () => setActiveId(record.id),
-        })}
-      />
+      <div className="grid grid-cols-[40px_60px_1fr_120px_120px] font-semibold border-b bg-gray-50 dark:bg-gray-700">
+        <div />
+        <button className="text-left touch-target" onClick={() => setSortField('id')}>{sortField === 'id' && (sortOrder === 'asc' ? '▲ ' : '▼ ')}ID</button>
+        <button className="text-left touch-target" onClick={() => setSortField('question')}>Question</button>
+        <button className="text-left touch-target" onClick={() => setSortField('status')}>Status</button>
+        <button className="text-left touch-target" onClick={() => setSortField('priority')}>Priority</button>
+      </div>
+      <List height={400} itemCount={sorted.length} itemSize={ROW_HEIGHT} width="100%">
+        {Row}
+      </List>
       <TicketDetailPanel ticketId={activeId} onClose={() => setActiveId(null)} />
     </div>
   );

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -57,7 +57,7 @@ export default function CommandPalette() {
         dataSource={filtered}
         renderItem={item => (
           <List.Item>
-            <button className="w-full text-left" onClick={() => handleSelect(item)}>
+            <button className="w-full text-left touch-target" onClick={() => handleSelect(item)}>
               {item.label}
             </button>
           </List.Item>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -12,7 +12,7 @@ export default function Sidebar() {
         type="text"
         icon={<MenuOutlined />}
         aria-label="Toggle navigation"
-        className="md:hidden"
+        className="md:hidden touch-target"
         onClick={() => setOpen(true)}
       />
       <Drawer

--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -1,143 +1,16 @@
-import { useEffect, useRef, useState } from 'react';
-import {
-  Chart as ChartJS,
-  registerables,
-  type ChartConfiguration,
-} from 'chart.js';
-import { Select, Button } from 'antd';
+import { useEffect, useState, lazy, Suspense } from 'react';
+import { Select } from 'antd';
 
-ChartJS.register(...registerables);
+const StatusWidget = lazy(() => import('./widgets/StatusWidget'));
+const ForecastWidget = lazy(() => import('./widgets/ForecastWidget'));
 
 type WidgetId = 'status' | 'forecast';
-
-interface ForecastData { forecast: number; }
-interface DashboardStats {
-  tickets: { open: number; waiting: number; closed: number };
-}
 
 const AVAILABLE_WIDGETS: { id: WidgetId; label: string }[] = [
   { id: 'status', label: 'Ticket Status' },
   { id: 'forecast', label: 'Ticket Forecast' },
 ];
 
-function StatusWidget({ onRemove }: { onRemove: () => void }) {
-  const [stats, setStats] = useState<DashboardStats | null>(null);
-  const ref = useRef<HTMLCanvasElement>(null);
-
-  async function loadStats() {
-    try {
-      const res = await fetch('/stats/dashboard');
-      const data: DashboardStats = await res.json();
-      setStats(data);
-    } catch (err) {
-      console.error('Error loading stats', err);
-    }
-  }
-
-  useEffect(() => {
-    loadStats();
-  }, []);
-
-  useEffect(() => {
-    if (!window.EventSource) return;
-    const es = new EventSource('/events');
-    es.addEventListener('ticketCreated', loadStats);
-    es.addEventListener('ticketUpdated', loadStats);
-    return () => es.close();
-  }, []);
-
-  useEffect(() => {
-    async function load() {
-      try {
-        const res = await fetch('/stats/dashboard');
-        const data: DashboardStats = await res.json();
-        setStats({ tickets: data.tickets });
-      } catch (err) {
-        console.error('Failed to load stats', err);
-      }
-    }
-    load();
-  }, []);
-
-  useEffect(() => {
-    if (!stats || !ref.current) return;
-
-    const cfg: ChartConfiguration<'bar'> = {
-      type: 'bar',
-      data: {
-        labels: ['Open', 'Waiting', 'Closed'],
-        datasets: [
-          {
-            data: [stats.tickets.open, stats.tickets.waiting, stats.tickets.closed],
-            backgroundColor: ['#3b82f6', '#facc15', '#10b981'],
-          },
-        ],
-      },
-      options: { plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true } } },
-    };
-    const chart = new ChartJS(ref.current, cfg);
-    return () => chart.destroy();
-  }, [stats]);
-
-  return (
-    <div className="border rounded p-2 bg-white dark:bg-gray-800">
-      <div className="flex justify-between items-center mb-1">
-        <h3 className="font-semibold">Ticket Status</h3>
-
-        <Button type="text" danger size="small" onClick={onRemove} aria-label="Remove">✕</Button>
-
-        <button aria-label="Remove" onClick={onRemove} className="text-sm text-error dark:text-error-dark">✕</button>
-
-      </div>
-      {stats ? <canvas ref={ref} /> : <p>Loading...</p>}
-    </div>
-  );
-}
-
-function ForecastWidget({ onRemove }: { onRemove: () => void }) {
-  const [forecast, setForecast] = useState<number | null>(null);
-  const ref = useRef<HTMLCanvasElement>(null);
-  const days = 14;
-
-  useEffect(() => {
-    async function load() {
-      try {
-        const res = await fetch(`/stats/forecast?days=${days}`);
-        const data: ForecastData = await res.json();
-        setForecast(data.forecast);
-      } catch (err) {
-        console.error('Failed to load forecast', err);
-      }
-    }
-    load();
-  }, []);
-
-  useEffect(() => {
-    if (forecast == null || !ref.current) return;
-    const labels = Array.from({ length: days }, (_, i) => `Day ${i + 1}`);
-    const daily = forecast / days;
-    const dataset = Array.from({ length: days }, () => daily);
-    const cfg: ChartConfiguration<'line'> = {
-      type: 'line',
-      data: { labels, datasets: [{ data: dataset, borderColor: '#3b82f6', fill: false }] },
-      options: { plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true } } },
-    };
-    const chart = new ChartJS(ref.current, cfg);
-    return () => chart.destroy();
-  }, [forecast]);
-
-  return (
-    <div className="border rounded p-2 bg-white dark:bg-gray-800">
-      <div className="flex justify-between items-center mb-1">
-        <h3 className="font-semibold">Ticket Forecast</h3>
-
-        <button aria-label="Remove" onClick={onRemove} className="text-sm text-error dark:text-error-dark">✕</button>
-
-      </div>
-      {forecast != null ? <canvas ref={ref} /> : <p>Loading...</p>}
-    </div>
-  );
-}
 
 function Widget({ id, onRemove }: { id: WidgetId; onRemove: () => void }) {
   switch (id) {
@@ -186,9 +59,8 @@ export default function StatsPanel() {
               {available.map(w => (
                 <Select.Option key={w.id} value={w.id}>{w.label}</Select.Option>
               ))}
-
-            </select>
-            <button onClick={addWidget} className="bg-primary dark:bg-primary-dark text-white px-2 py-0.5 rounded">
+            </Select>
+            <button onClick={addWidget} className="bg-primary dark:bg-primary-dark text-white px-2 py-0.5 rounded touch-target">
               Add
             </button>
 
@@ -197,7 +69,9 @@ export default function StatsPanel() {
       </div>
       <div className="grid gap-4 sm:grid-cols-2">
         {widgets.map(id => (
-          <Widget key={id} id={id} onRemove={() => removeWidget(id)} />
+          <Suspense key={id} fallback={<p>Loading...</p>}>
+            <Widget id={id} onRemove={() => removeWidget(id)} />
+          </Suspense>
         ))}
       </div>
     </section>

--- a/frontend/src/components/widgets/ForecastWidget.tsx
+++ b/frontend/src/components/widgets/ForecastWidget.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from 'react';
+import { Chart as ChartJS, registerables, type ChartConfiguration } from 'chart.js';
+
+ChartJS.register(...registerables);
+
+interface ForecastData { forecast: number; }
+
+export default function ForecastWidget({ onRemove }: { onRemove: () => void }) {
+  const [forecast, setForecast] = useState<number | null>(null);
+  const ref = useRef<HTMLCanvasElement>(null);
+  const days = 14;
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/stats/forecast?days=${days}`);
+        const data: ForecastData = await res.json();
+        setForecast(data.forecast);
+      } catch (err) {
+        console.error('Failed to load forecast', err);
+      }
+    }
+    load();
+  }, []);
+
+  useEffect(() => {
+    if (forecast == null || !ref.current) return;
+    const labels = Array.from({ length: days }, (_, i) => `Day ${i + 1}`);
+    const daily = forecast / days;
+    const dataset = Array.from({ length: days }, () => daily);
+    const cfg: ChartConfiguration<'line'> = {
+      type: 'line',
+      data: { labels, datasets: [{ data: dataset, borderColor: '#3b82f6', fill: false }] },
+      options: { plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true } } },
+    };
+    const chart = new ChartJS(ref.current, cfg);
+    return () => chart.destroy();
+  }, [forecast]);
+
+  return (
+    <div className="border rounded p-2 bg-white dark:bg-gray-800">
+      <div className="flex justify-between items-center mb-1">
+        <h3 className="font-semibold">Ticket Forecast</h3>
+        <button aria-label="Remove" onClick={onRemove} className="text-sm text-error dark:text-error-dark touch-target">✕</button>
+      </div>
+      {forecast != null ? <canvas ref={ref} /> : <p>Loading...</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/widgets/StatusWidget.tsx
+++ b/frontend/src/components/widgets/StatusWidget.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from 'react';
+import { Chart as ChartJS, registerables, type ChartConfiguration } from 'chart.js';
+
+ChartJS.register(...registerables);
+
+interface DashboardStats {
+  tickets: { open: number; waiting: number; closed: number };
+}
+
+export default function StatusWidget({ onRemove }: { onRemove: () => void }) {
+  const [stats, setStats] = useState<DashboardStats | null>(null);
+  const ref = useRef<HTMLCanvasElement>(null);
+
+  async function loadStats() {
+    try {
+      const res = await fetch('/stats/dashboard');
+      const data: DashboardStats = await res.json();
+      setStats(data);
+    } catch (err) {
+      console.error('Error loading stats', err);
+    }
+  }
+
+  useEffect(() => {
+    loadStats();
+  }, []);
+
+  useEffect(() => {
+    if (!window.EventSource) return;
+    const es = new EventSource('/events');
+    es.addEventListener('ticketCreated', loadStats);
+    es.addEventListener('ticketUpdated', loadStats);
+    return () => es.close();
+  }, []);
+
+  useEffect(() => {
+    if (!stats || !ref.current) return;
+    const cfg: ChartConfiguration<'bar'> = {
+      type: 'bar',
+      data: {
+        labels: ['Open', 'Waiting', 'Closed'],
+        datasets: [
+          {
+            data: [stats.tickets.open, stats.tickets.waiting, stats.tickets.closed],
+            backgroundColor: ['#3b82f6', '#facc15', '#10b981'],
+          },
+        ],
+      },
+      options: { plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true } } },
+    };
+    const chart = new ChartJS(ref.current, cfg);
+    return () => chart.destroy();
+  }, [stats]);
+
+  return (
+    <div className="border rounded p-2 bg-white dark:bg-gray-800">
+      <div className="flex justify-between items-center mb-1">
+        <h3 className="font-semibold">Ticket Status</h3>
+        <button aria-label="Remove" onClick={onRemove} className="text-sm text-error dark:text-error-dark touch-target">✕</button>
+      </div>
+      {stats ? <canvas ref={ref} /> : <p>Loading...</p>}
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,6 +3,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .touch-target {
+    @apply min-w-11 min-h-11 flex items-center justify-center;
+  }
+}
+
 body {
 
   @apply transition-colors duration-300 font-sans;

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -306,7 +306,7 @@ export default function UserProfile() {
               <button
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
-                className={`py-4 px-1 border-b-2 font-medium text-sm transition-colors ${
+                className={`py-4 px-1 border-b-2 font-medium text-sm transition-colors touch-target ${
                   activeTab === tab.id
                     ? 'border-blue-500 text-blue-600 dark:text-blue-400'
                     : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300'

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,10 @@
         "@types/node": "^20.4.2",
         "@types/uuid": "^9.0.0",
         "prettier": "^3.0.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-swipeable": "^7.0.0",
+        "react-window": "^1.8.7",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.0"
       }
@@ -395,6 +399,16 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2317,6 +2331,13 @@
       "resolved": "https://registry.npmmirror.com/js-md4/-/js-md4-0.3.2.tgz",
       "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA=="
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsbi": {
       "version": "4.3.2",
       "resolved": "https://registry.npmmirror.com/jsbi/-/jsbi-4.3.2.tgz",
@@ -2402,6 +2423,19 @@
       "resolved": "https://registry.npmmirror.com/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmmirror.com/make-dir/-/make-dir-3.1.0.tgz",
@@ -2445,6 +2479,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
@@ -2855,6 +2896,61 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -3000,6 +3096,16 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -4022,6 +4128,12 @@
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
+    },
+    "@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "dev": true
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -5402,6 +5514,12 @@
       "resolved": "https://registry.npmmirror.com/js-md4/-/js-md4-0.3.2.tgz",
       "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA=="
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
     "jsbi": {
       "version": "4.3.2",
       "resolved": "https://registry.npmmirror.com/jsbi/-/jsbi-4.3.2.tgz",
@@ -5485,6 +5603,15 @@
       "resolved": "https://registry.npmmirror.com/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmmirror.com/make-dir/-/make-dir-3.1.0.tgz",
@@ -5515,6 +5642,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmmirror.com/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
+    },
+    "memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.3",
@@ -5789,6 +5922,42 @@
         "unpipe": "1.0.0"
       }
     },
+    "react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      }
+    },
+    "react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "dev": true,
+      "requires": {}
+    },
+    "react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      }
+    },
     "readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -5880,6 +6049,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "semver": {
       "version": "7.7.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "@types/uuid": "^9.0.0",
     "prettier": "^3.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.2.0"
+    "typescript": "^5.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-window": "^1.8.7",
+    "react-swipeable": "^7.0.0"
   }
 }

--- a/public/chat.html
+++ b/public/chat.html
@@ -14,14 +14,14 @@
 
   <header class="flex justify-between items-center py-4">
     <div class="flex items-center gap-2">
-      <button id="menuToggle" aria-controls="sidebar" aria-expanded="false" class="border p-2 md:hidden">☰</button>
+      <button id="menuToggle" aria-controls="sidebar" aria-expanded="false" class="border p-2 md:hidden touch-target">☰</button>
       <h1 class="text-2xl font-bold">AI Chat</h1>
     </div>
     <nav class="hidden md:block">
       <a href="/index.html" class="text-blue-600 hover:underline mr-4">Home</a>
       <a href="/realtime.html" class="text-blue-600 hover:underline">Real-Time</a>
     </nav>
-    <button id="themeToggle" type="button" aria-label="Toggle dark mode" class="ml-4">🌓</button>
+    <button id="themeToggle" type="button" aria-label="Toggle dark mode" class="ml-4 touch-target">🌓</button>
   </header>
 
   <nav id="sidebar" aria-label="Sidebar" class="fixed inset-y-0 left-0 w-56 bg-gray-100 dark:bg-gray-900 p-4 transform -translate-x-full transition-transform md:static md:translate-x-0 md:w-48">
@@ -36,8 +36,8 @@
     <form id="chatForm" class="flex gap-2">
       <label for="msg" class="visually-hidden">Message</label>
       <input id="msg" placeholder="Ask a question..." size="50" class="border flex-grow p-2" />
-      <button id="voice" type="button" aria-label="Start voice input" class="border px-3">🎤</button>
-      <button type="submit" class="border px-4">Send</button>
+      <button id="voice" type="button" aria-label="Start voice input" class="border px-3 touch-target">🎤</button>
+      <button type="submit" class="border px-4 touch-target">Send</button>
     </form>
     <div id="suggestions" class="mt-2 space-x-2"></div>
   </main>

--- a/public/index.html
+++ b/public/index.html
@@ -15,14 +15,14 @@
 
   <header class="flex justify-between items-center py-4">
     <div class="flex items-center gap-2">
-      <button id="menuToggle" aria-controls="sidebar" aria-expanded="false" aria-label="Toggle navigation" class="border p-2 md:hidden">☰</button>
+      <button id="menuToggle" aria-controls="sidebar" aria-expanded="false" aria-label="Toggle navigation" class="border p-2 md:hidden touch-target">☰</button>
       <h1 class="text-2xl font-bold">AI Powered Help Desk</h1>
     </div>
     <nav class="hidden md:block">
       <a href="/chat.html" class="text-blue-600 hover:underline mr-4">AI Chat</a>
       <a href="/realtime.html" class="text-blue-600 hover:underline">Real-Time</a>
     </nav>
-    <button id="themeToggle" type="button" aria-label="Toggle dark mode" class="ml-4">🌓</button>
+    <button id="themeToggle" type="button" aria-label="Toggle dark mode" class="ml-4 touch-target">🌓</button>
   </header>
 
   <nav id="sidebar" aria-label="Sidebar" tabindex="-1" class="fixed inset-y-0 left-0 w-56 bg-gray-100 dark:bg-gray-900 p-4 transform -translate-x-full transition-transform md:static md:translate-x-0 md:w-48">
@@ -47,7 +47,7 @@
       <label for="search" class="visually-hidden">Search tickets</label>
       <input id="search" type="search" placeholder="Search tickets..." list="suggestions" autocomplete="off" class="border p-2 flex-grow" />
       <datalist id="suggestions"></datalist>
-      <button type="submit" class="border px-3 py-2">Search</button>
+      <button type="submit" class="border px-3 py-2 touch-target">Search</button>
     </form>
 
     <div class="flex items-center gap-2 mb-2">

--- a/public/styles.css
+++ b/public/styles.css
@@ -58,6 +58,13 @@ a {
 }
 button {
   padding: 0.5em 1em;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.touch-target {
+  min-width: 44px;
+  min-height: 44px;
 }
 #themeToggle {
   margin-left: 1em;

--- a/public/ticket.html
+++ b/public/ticket.html
@@ -12,14 +12,14 @@
   <a href="#main" class="skip-link">Skip to content</a>
   <header class="flex justify-between items-center py-4">
     <div class="flex items-center gap-2">
-      <button id="menuToggle" aria-controls="sidebar" aria-expanded="false" class="border p-2 md:hidden">☰</button>
+      <button id="menuToggle" aria-controls="sidebar" aria-expanded="false" class="border p-2 md:hidden touch-target">☰</button>
       <h1 class="text-2xl font-bold">Ticket Details</h1>
     </div>
     <nav class="hidden md:block">
       <a href="/index.html" class="text-blue-600 hover:underline mr-4">Home</a>
       <a href="/realtime.html" class="text-blue-600 hover:underline">Real-Time</a>
     </nav>
-    <button id="themeToggle" type="button" aria-label="Toggle dark mode" class="ml-4">🌓</button>
+    <button id="themeToggle" type="button" aria-label="Toggle dark mode" class="ml-4 touch-target">🌓</button>
   </header>
 
   <nav id="sidebar" aria-label="Sidebar" class="fixed inset-y-0 left-0 w-56 bg-gray-100 dark:bg-gray-900 p-4 transform -translate-x-full transition-transform md:static md:translate-x-0 md:w-48">

--- a/tests/lazyModules.test.js
+++ b/tests/lazyModules.test.js
@@ -1,0 +1,14 @@
+require("ts-node/register");
+const assert = require("assert");
+
+(async () => {
+  const { default: Dashboard } = await import(
+    "../frontend/src/pages/Dashboard"
+  );
+  const { default: StatusWidget } = await import(
+    "../frontend/src/components/widgets/StatusWidget"
+  );
+  assert.equal(typeof Dashboard, "function");
+  assert.equal(typeof StatusWidget, "function");
+  console.log("Lazy modules test passed");
+})();

--- a/tests/virtualScrolling.test.js
+++ b/tests/virtualScrolling.test.js
@@ -1,0 +1,22 @@
+require("ts-node/register");
+const assert = require("assert");
+const React = require("../frontend/node_modules/react");
+const ReactDOMServer = require("../frontend/node_modules/react-dom/server");
+const TicketTable = require("../frontend/src/TicketTable").default;
+
+const tickets = Array.from({ length: 50 }, (_, i) => ({
+  id: i + 1,
+  question: `Q${i + 1}`,
+  status: "open",
+  priority: "low",
+}));
+
+const html = ReactDOMServer.renderToString(
+  React.createElement(TicketTable, { filters: {}, tickets }),
+);
+
+assert(
+  !html.includes("Q50"),
+  "last ticket should not be rendered with virtual scroll",
+);
+console.log("Virtual scrolling test passed");


### PR DESCRIPTION
## Summary
- enforce minimum touch target size in CSS
- update HTML and React components to use the `touch-target` class
- replace ticket table with a virtualized, swipeable version
- lazily load dashboard widgets and routes
- add basic tests for lazy modules and virtual scrolling

## Testing
- `npm test` *(fails: Aging tickets test passed then process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68758ea47770832b986418a3c8d7e4a1