### PR TITLE
Add sentiment analysis service

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ For a summary of the modernization vision and design standards, read
 - **Ticket management API** for creating, updating and commenting on tickets. Ticket history records status, assignee, priority and due date changes.
 - **Asset management API** for tracking staff equipment.
 - **AI endpoint** that forwards natural language text to an n8n workflow for processing.
+- **Sentiment analysis** for tickets and comments using a simple NLP model.
 - Mock data for users, tickets and assets to simulate a database.
 - **Qdrant client script** for indexing ticket text in a vector database.
 - **Automatic Qdrant indexing** of newly created tickets when the server is running.
@@ -62,6 +63,7 @@ For a summary of the modernization vision and design standards, read
 - `GET /tickets/recent?limit=n` – list the most recently created tickets (default 5).
 - `GET /tickets/unassigned` – list tickets that have no assignee.
 - `GET /events` – subscribe to real-time ticket events via Server-Sent Events.
+- `POST /sentiment` – analyze text and return a sentiment score and label.
 - `GET /assets` – list all assets. Filter by tag with `?tag=value` or by assignee with `?assignedTo=userId`.
   Results may also be sorted with `?sortBy=field&order=asc|desc`.
 - `POST /assets` – create a new asset with `name`, optional `assignedTo` and optional `tags` array. Creation is recorded in the asset's history.
@@ -110,6 +112,11 @@ For a summary of the modernization vision and design standards, read
 3. Start the server:
    ```bash
    npm start
+   ```
+   You can test sentiment analysis with:
+   ```bash
+   curl -X POST -H "Content-Type: application/json" \
+        -d '{"text":"I love this"}' http://localhost:3000/sentiment
    ```
 4. Run tests:
    ```bash

--- a/frontend/src/TicketTable.tsx
+++ b/frontend/src/TicketTable.tsx
@@ -9,6 +9,7 @@ interface Ticket {
   question: string;
   status: string;
   priority: string;
+  sentiment?: { label: string; score: number };
 }
 
 interface Props {
@@ -81,9 +82,20 @@ export default function TicketTable({ filters }: Props) {
     }
   }
 
+  function emoji(label: string) {
+    if (label === 'positive') return '🙂';
+    if (label === 'negative') return '😠';
+    return '😐';
+  }
+
   const columns = [
     { title: 'ID', dataIndex: 'id', sorter: true },
     { title: 'Question', dataIndex: 'question', sorter: true },
+    {
+      title: 'Sentiment',
+      dataIndex: 'sentiment',
+      render: (s: Ticket['sentiment']) => (s ? emoji(s.label) : ''),
+    },
     { title: 'Status', dataIndex: 'status', sorter: true },
     { title: 'Priority', dataIndex: 'priority', sorter: true },
   ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.0",
         "mssql": "^10.0.0",
+        "sentiment": "^5.0.2",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -3049,6 +3050,15 @@
       "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/sentiment": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sentiment/-/sentiment-5.0.2.tgz",
+      "integrity": "sha512-ZeC3y0JsOYTdwujt5uOd7ILJNilbgFzUtg/LEG4wUv43LayFNLZ28ec8+Su+h3saHlJmIwYxBzfDHHZuiMA15g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "resolved": "https://registry.npmmirror.com/serve-static/-/serve-static-1.16.2.tgz",
@@ -5918,6 +5928,11 @@
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
+    },
+    "sentiment": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sentiment/-/sentiment-5.0.2.tgz",
+      "integrity": "sha512-ZeC3y0JsOYTdwujt5uOd7ILJNilbgFzUtg/LEG4wUv43LayFNLZ28ec8+Su+h3saHlJmIwYxBzfDHHZuiMA15g=="
     },
     "serve-static": {
       "version": "1.16.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
     "mssql": "^10.0.0",
+    "sentiment": "^5.0.2",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const data = require("./data/mockData");
 const dataService = require("./utils/dataService");
 const auth = require("./utils/authService");
 const eventBus = require("./utils/eventBus");
+const sentimentService = require("./utils/sentimentService");
 
 const fs = require('fs');
 const app = express();
@@ -157,6 +158,9 @@ app.get("/tickets", async (req, res) => {
       return av > bv ? dir : av < bv ? -dir : 0;
     });
   }
+  tickets.forEach(t => {
+    if (!t.sentiment) t.sentiment = sentimentService.analyze(t.question);
+  });
   res.json(tickets);
 });
 
@@ -220,6 +224,7 @@ app.post("/tickets", (req, res) => {
     status: "open",
     priority: priority || "medium",
     question,
+    sentiment: sentimentService.analyze(question),
     dueDate: dueDate || null,
     tags: Array.isArray(tags) ? tags : [],
     comments: [],
@@ -550,6 +555,7 @@ app.post("/tickets/:id/comments", (req, res) => {
     text,
     html: highlighted,
     mentions,
+    sentiment: sentimentService.analyze(text),
     isInternal: !!isInternal,
     date: new Date().toISOString(),
   };
@@ -604,6 +610,7 @@ app.patch("/tickets/:id/comments/:commentId", (req, res) => {
   if (!text) return res.status(400).json({ error: "text required" });
   comment.text = text;
   comment.html = parseMentions(text).highlighted;
+  comment.sentiment = sentimentService.analyze(text);
   comment.edited = new Date().toISOString();
   res.json(comment);
 });
@@ -703,6 +710,7 @@ app.get("/tickets/recent", (req, res) => {
 app.get("/tickets/:id", async (req, res) => {
   const ticket = await dataService.getTicketById(Number(req.params.id));
   if (!ticket) return res.status(404).json({ error: "Ticket not found" });
+  if (!ticket.sentiment) ticket.sentiment = sentimentService.analyze(ticket.question);
   res.json(ticket);
 });
 app.get("/stats", (req, res) => {
@@ -1203,6 +1211,14 @@ app.post("/ai", async (req, res) => {
     console.error(err);
     res.status(500).json({ error: "Failed to process text" });
   }
+});
+
+// Sentiment analysis endpoint
+app.post("/sentiment", (req, res) => {
+  const { text } = req.body;
+  if (!text) return res.status(400).json({ error: "text required" });
+  const result = sentimentService.analyze(text);
+  res.json(result);
 });
 
 app.get('*', (req, res) => {

--- a/tests/sentiment.test.js
+++ b/tests/sentiment.test.js
@@ -1,0 +1,60 @@
+const http = require('http');
+const assert = require('assert');
+const app = require('../server');
+
+const server = app.listen(0, () => {
+  const port = server.address().port;
+  const req = http.request({
+    port,
+    path: '/sentiment',
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' }
+  }, res => {
+    let data = '';
+    res.on('data', c => data += c);
+    res.on('end', () => {
+      const result = JSON.parse(data);
+      assert.strictEqual(result.label, 'positive');
+      createTicket();
+    });
+  });
+  req.end(JSON.stringify({ text: 'I love this product' }));
+
+  function createTicket() {
+    const create = http.request({
+      port,
+      path: '/tickets',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    }, res => {
+      let body = '';
+      res.on('data', d => body += d);
+      res.on('end', () => {
+        const ticket = JSON.parse(body);
+        assert.ok(ticket.sentiment);
+        assert.strictEqual(ticket.sentiment.label, 'positive');
+        addComment(ticket.id);
+      });
+    });
+    create.end(JSON.stringify({ question: 'Great service!' }));
+  }
+
+  function addComment(id) {
+    const commentReq = http.request({
+      port,
+      path: `/tickets/${id}/comments`,
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    }, res => {
+      let out = '';
+      res.on('data', d => out += d);
+      res.on('end', () => {
+        const comment = JSON.parse(out);
+        assert.ok(comment.sentiment);
+        assert.strictEqual(comment.sentiment.label, 'negative');
+        server.close(() => console.log('Sentiment analysis test passed'));
+      });
+    });
+    commentReq.end(JSON.stringify({ text: 'terrible experience' }));
+  }
+});

--- a/utils/sentimentService.js
+++ b/utils/sentimentService.js
@@ -1,0 +1,12 @@
+const Sentiment = require('sentiment');
+const analyzer = new Sentiment();
+
+function analyze(text) {
+  const { score } = analyzer.analyze(text || '');
+  let label = 'neutral';
+  if (score > 1) label = 'positive';
+  else if (score < -1) label = 'negative';
+  return { score, label };
+}
+
+module.exports = { analyze };


### PR DESCRIPTION
## Summary
- analyze text sentiment with a new utility
- expose `/sentiment` API endpoint
- store sentiment with tickets and comments
- show sentiment emojis in the ticket table
- test the sentiment endpoint and storage
- document the new feature in the README

## Testing
- `npm test` *(fails: Aging tickets test passed and then process hung)*

------
https://chatgpt.com/codex/tasks/task_e_6875904e12f8832b88058045c4ac4156