### PR TITLE
Add NLP ticket categorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ For a summary of the modernization vision and design standards, read
 - **Ticket management API** for creating, updating and commenting on tickets. Ticket history records status, assignee, priority and due date changes.
 - **Asset management API** for tracking staff equipment.
 - **AI endpoint** that forwards natural language text to an n8n workflow for processing.
+- **NLP-based routing** automatically assigns and prioritizes new tickets based on their content when no assignee or priority is provided.
 - Mock data for users, tickets and assets to simulate a database.
 - **Qdrant client script** for indexing ticket text in a vector database.
 - **Automatic Qdrant indexing** of newly created tickets when the server is running.
@@ -36,7 +37,9 @@ For a summary of the modernization vision and design standards, read
     `GET /tickets?status=open&priority=high&tag=urgent&assignee=1&submitter=2`.
     Results may also be sorted with `?sortBy=field&order=asc|desc`.
 - `GET /tickets/:id` – view a specific ticket.
-- `POST /tickets` – create a new ticket. Requires a `question` field in the body.
+- `POST /tickets` – create a new ticket. Requires a `question` field. When
+  `assigneeId` or `priority` are omitted, the text is analyzed and defaults are
+  chosen based on the detected category.
 - `PATCH /tickets/:id` – update ticket status, assignee, priority or `dueDate`.
 - `DELETE /tickets/:id` – remove a ticket completely.
 - `POST /tickets/:id/reassign-least-busy` – automatically assign the ticket to the agent with the fewest open tickets.

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -15,6 +15,8 @@ This document outlines a proposed five phase roadmap for evolving the existing h
 ## Phase 3 – Advanced Analytics & AI Intelligence
 - Build analytics dashboards with predictive metrics such as MTTR and ticket volume forecasts.
 - Enhance the AI service to support intelligent routing, sentiment analysis and anomaly detection.
+- An initial Naive Bayes classifier now selects default assignees and priorities
+  for new tickets based on their text content.
 - Add interactive visualization components and machine learning pipelines.
 
 ## Phase 4 – Mobile & Integration Platform

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
     "mssql": "^10.0.0",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "natural": "^8.1.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.0",

--- a/tests/ticketAiRouting.test.js
+++ b/tests/ticketAiRouting.test.js
@@ -1,0 +1,34 @@
+const http = require('http');
+const assert = require('assert');
+const app = require('../server');
+
+const server = app.listen(0, () => {
+  const port = server.address().port;
+  const create1 = http.request(
+    { port, path: '/tickets', method: 'POST', headers: { 'Content-Type': 'application/json' } },
+    res => {
+      let body = '';
+      res.on('data', c => body += c);
+      res.on('end', () => {
+        const ticket = JSON.parse(body);
+        assert.strictEqual(ticket.assigneeId, 1);
+        assert.strictEqual(ticket.priority, 'medium');
+        const create2 = http.request(
+          { port, path: '/tickets', method: 'POST', headers: { 'Content-Type': 'application/json' } },
+          res2 => {
+            let b2 = '';
+            res2.on('data', d => b2 += d);
+            res2.on('end', () => {
+              const ticket2 = JSON.parse(b2);
+              assert.strictEqual(ticket2.assigneeId, 2);
+              assert.strictEqual(ticket2.priority, 'high');
+              server.close(() => console.log('AI routing test passed'));
+            });
+          }
+        );
+        create2.end(JSON.stringify({ question: 'The server had an error.' }));
+      });
+    }
+  );
+  create1.end(JSON.stringify({ question: 'I forgot my password' }));
+});

--- a/utils/aiService.js
+++ b/utils/aiService.js
@@ -1,12 +1,30 @@
-// Placeholder for advanced AI processing
-// In a real implementation this would use machine learning models
-// to categorize tickets and provide automated responses.
+const natural = require('natural');
+
+// Naive Bayes classifier trained with a few example phrases
+const classifier = new natural.BayesClassifier();
+classifier.addDocument('reset my password', 'authentication');
+classifier.addDocument('forgot password', 'authentication');
+classifier.addDocument('cannot login', 'authentication');
+classifier.addDocument('server error', 'incident');
+classifier.addDocument('application crashed', 'incident');
+classifier.addDocument('received error code', 'incident');
+classifier.addDocument('general question', 'general');
+classifier.addDocument('how does this work', 'general');
+classifier.train();
+
+const categoryDefaults = {
+  authentication: { assigneeId: 1, priority: 'medium' },
+  incident: { assigneeId: 2, priority: 'high' },
+  general: {},
+};
 
 function categorizeTicket(text) {
-  text = text.toLowerCase();
-  if (text.includes("password")) return "authentication";
-  if (text.includes("error")) return "incident";
-  return "general";
+  if (!text) return 'general';
+  try {
+    return classifier.classify(text) || 'general';
+  } catch {
+    return 'general';
+  }
 }
 
-module.exports = { categorizeTicket };
+module.exports = { categorizeTicket, categoryDefaults };


### PR DESCRIPTION
## Summary
- integrate `natural` and implement simple Naive Bayes model in `utils/aiService.js`
- map categories to default assignees and priorities
- apply NLP routing when creating tickets
- describe the behaviour in README and development plan
- add unit test verifying NLP routing

## Testing
- `node tests/ticketAiRouting.test.js`
- `timeout 30s node run-tests.js` *(fails: hangs after first test)*

------
https://chatgpt.com/codex/tasks/task_e_6875904f3258832ba7144be060e8f8e9