### PR TITLE
Fix duplicated API key line in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,13 +39,8 @@ QDRANT_URL=http://localhost:6333
 
 # OpenAI API key for aiService
 OPENAI_API_KEY=
-
-
-# OpenAI API key for aiService
-OPENAI_API_KE
 # Translation service base URL
 TRANSLATE_URL=http://localhost:4000/translate
 # Optional API key for translation provider
 TRANSLATE_API_KEY=your_translation_api_key
-
 


### PR DESCRIPTION
## Summary
- clean up the `.env.example` file by removing a truncated duplicate variable

## Testing
- `npm test` *(fails: SyntaxError in server.js)*

------
https://chatgpt.com/codex/tasks/task_e_6875b0d905a4832bab4f1ae88159eda4