### PR TITLE
Fix frontend main.tsx composition

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,30 +1,20 @@
 
-import React from "react";
-import ReactDOM from "react-dom/client";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import App from "./App";
-import "./index.css";
-
-const queryClient = new QueryClient();
-
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
-
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import 'antd/dist/reset.css';
 import './index.css';
 import { ThemeProvider } from './hooks/useTheme';
 
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <ThemeProvider>
-      <App />
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
     </ThemeProvider>
-
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- fix duplicate imports and unify React root render
- compose `QueryClientProvider` inside `ThemeProvider`

## Testing
- `npm run format` *(fails: SyntaxError in server.js and package-lock.json)*
- `npm test` *(fails to load tests due to SyntaxError in server.js)*

------
https://chatgpt.com/codex/tasks/task_e_6875b0c711c8832b8149ac7b11f68029