### PR TITLE
Update roadmap and mention new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ For a summary of the modernization vision and design standards, read
 - **Wildcard routing** using `*` to match any path.
 
 - **Stats dashboard** showing ticket counts, mean resolution time and a 7-day ticket forecast.
+- **Knowledge base integration** with AI-suggested articles.
+- **Self-service portal** for users to search articles and track tickets.
+- **Community forums** to share solutions and ideas.
 
 
 ### API Endpoints
@@ -165,6 +168,8 @@ Other useful environment variables include:
 - `OPENAI_API_KEY` – API key for calling OpenAI services used by `aiService`.
 - `TRANSLATE_URL` – HTTP endpoint for the translation service.
 - `TRANSLATE_API_KEY` – API key used when contacting the translation provider.
+- `CORS_ORIGIN` – allowed origin for the React frontend.
+- `DEFAULT_LANGUAGE` – default language code for translations.
 
 After the first visit, the pages are cached for offline use via a service worker.
 An experimental `realtime.html` page demonstrates live ticket notifications using the `/events` SSE endpoint.
@@ -180,7 +185,8 @@ the session.
 
 The user interface has moved to a React application in the `frontend` directory.
 Before starting the server, run `npm install && npm run build` in that folder to
-produce the `dist` directory. A blank page or MIME type errors in the browser
+produce the `dist` directory. This build now compiles the knowledge base,
+self-service portal and community pages. A blank page or MIME type errors in the browser
 usually mean the `frontend/dist` directory is missing or the server could not
 find it. During development you can run `npm run dev` for hot reloading. The dashboard includes
 ticket tables, real-time updates via Server-Sent Events and a new analytics

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -29,4 +29,24 @@ This document outlines a proposed five phase roadmap for evolving the existing h
 - Introduce scalability features such as load balancing, caching and message queues.
 - Offer advanced reporting, AI/ML capabilities and governance tools.
 
+## Phase 6 – Knowledge Base & Self‑Service
+- Build an article management system powering a searchable knowledge base.
+- Surface AI-curated suggestions when users create or view tickets.
+- Launch a self-service portal for browsing articles and opening requests.
+
+## Phase 7 – Community & Peer Support
+- Provide discussion forums and community Q&A linked to tickets.
+- Allow upvoting of solutions and marking accepted answers.
+- Encourage contributions with badges and leaderboards.
+
+## Phase 8 – Workflow Automation & AI Bots
+- Expand the visual workflow engine to orchestrate cross-team hand‑offs.
+- Introduce chat bots for routine requests and guided self-service.
+- Offer pluggable automations with usage analytics.
+
+## Phase 9 – Observability & Compliance
+- Implement centralized logging and performance monitoring dashboards.
+- Add audit trails and compliance reporting features.
+- Optimize CI/CD pipelines for automated testing and deployment.
+
 This phased approach ensures incremental improvements while maintaining compatibility with the current system.


### PR DESCRIPTION
## Summary
- expand development plan with phases 6–9
- highlight knowledge base, self-service portal and community forums in README
- document `CORS_ORIGIN` and `DEFAULT_LANGUAGE` variables
- note that frontend build compiles the new pages

## Testing
- `npm install`
- `npm test` *(fails: Identifier 'assignedId' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6875b0abcf9c832b89a6c9a32ffcf14c