### PR TITLE
Fix aiService export structure

### DIFF
--- a/utils/aiService.js
+++ b/utils/aiService.js
@@ -28,7 +28,6 @@ function categorizeTicket(text) {
   }
 }
 
-module.exports = { categorizeTicket, categoryDefaults };
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const OPENAI_URL = 'https://api.openai.com/v1/chat/completions';
@@ -51,39 +50,6 @@ async function callOpenAI(messages) {
 }
 
 
-function analyzeSentiment(text) {
-  text = text.toLowerCase();
-  const positiveWords = [
-    'good',
-    'great',
-    'excellent',
-    'love',
-    'awesome',
-    'thank',
-    'thanks',
-  ];
-  const negativeWords = [
-    'bad',
-    'terrible',
-    'awful',
-    'hate',
-    'slow',
-    'broken',
-    'error',
-  ];
-  let score = 0;
-  positiveWords.forEach((w) => {
-    if (text.includes(w)) score++;
-  });
-  negativeWords.forEach((w) => {
-    if (text.includes(w)) score--;
-  });
-  if (score > 0) return 'positive';
-  if (score < 0) return 'negative';
-  return 'neutral';
-}
-
-module.exports = { categorizeTicket, analyzeSentiment };
 
 function simpleDetect(text) {
   const lower = text.toLowerCase();
@@ -147,6 +113,8 @@ async function suggestTags(text) {
 }
 
 module.exports = {
+  categorizeTicket,
+  categoryDefaults,
   analyzeSentiment,
   suggestTags,
   detectLanguage,


### PR DESCRIPTION
## Summary
- remove duplicate sentiment helper
- consolidate exports in `utils/aiService.js`

## Testing
- `npm test` *(fails: Identifier 'assignedId' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6875b0a35374832bab131df576d1043e