### PR TITLE
Add mobile app skeleton with React Native

### DIFF
--- a/mobile-app/App.js
+++ b/mobile-app/App.js
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import * as Notifications from 'expo-notifications';
+import * as LocalAuthentication from 'expo-local-authentication';
+import { Camera } from 'expo-camera';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { View, Text, FlatList, Button, TouchableOpacity, Image } from 'react-native';
+
+const Stack = createNativeStackNavigator();
+const API_URL = 'http://localhost:3000';
+
+function TicketList({ navigation }) {
+  const [tickets, setTickets] = useState([]);
+
+  async function fetchTickets() {
+    try {
+      const cached = await AsyncStorage.getItem('tickets');
+      if (cached) setTickets(JSON.parse(cached));
+      const res = await fetch(`${API_URL}/tickets`);
+      const data = await res.json();
+      setTickets(data);
+      await AsyncStorage.setItem('tickets', JSON.stringify(data));
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  useEffect(() => {
+    fetchTickets();
+  }, []);
+
+  return (
+    <FlatList
+      data={tickets}
+      keyExtractor={(item) => String(item.id)}
+      renderItem={({ item }) => (
+        <TouchableOpacity onPress={() => navigation.navigate('Detail', { id: item.id })}>
+          <View style={{ padding: 16, borderBottomWidth: 1 }}>
+            <Text>{item.question}</Text>
+          </View>
+        </TouchableOpacity>
+      )}
+    />
+  );
+}
+
+function TicketDetail({ route }) {
+  const { id } = route.params;
+  const [ticket, setTicket] = useState(null);
+  const [image, setImage] = useState(null);
+
+  async function load() {
+    try {
+      const res = await fetch(`${API_URL}/tickets/${id}`);
+      const data = await res.json();
+      setTicket(data);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function takePhoto() {
+    const { status } = await Camera.requestCameraPermissionsAsync();
+    if (status === 'granted') {
+      const cam = await Camera.openCameraAsync({ allowsEditing: true });
+      if (!cam.cancelled) setImage(cam.uri);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  if (!ticket) return <Text>Loading...</Text>;
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text style={{ fontSize: 18, marginBottom: 12 }}>{ticket.question}</Text>
+      {image && <Image source={{ uri: image }} style={{ width: 200, height: 200 }} />}
+      <Button title="Attach Photo" onPress={takePhoto} />
+    </View>
+  );
+}
+
+export default function App() {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    async function prepare() {
+      const enrolled = await LocalAuthentication.hasHardwareAsync();
+      if (enrolled) {
+        await LocalAuthentication.authenticateAsync();
+      }
+      await Notifications.requestPermissionsAsync();
+      setReady(true);
+    }
+    prepare();
+  }, []);
+
+  if (!ready) return <View />;
+
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Tickets" component={TicketList} />
+        <Stack.Screen name="Detail" component={TicketDetail} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/mobile-app/babel.config.js
+++ b/mobile-app/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo']
+  };
+};

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "mobile-app",
+  "version": "1.0.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "expo-notifications": "~0.21.0",
+    "expo-camera": "~14.0.0",
+    "expo-local-authentication": "~15.0.0",
+    "@react-native-async-storage/async-storage": "^1.21.0",
+    "react": "18.2.0",
+    "react-native": "0.73.0",
+    "react-native-paper": "^5.10.0",
+    "react-navigation": "^4.4.4",
+    "@react-navigation/native": "^6.1.8",
+    "@react-navigation/native-stack": "^6.9.12"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -298,8 +298,6 @@ app.post("/tickets", async (req, res) => {
   if (finalPriority === undefined) finalPriority = "medium";
 
   const { translated, lang } = await translation.translateToDefault(question);
-  const assignedId =
-    assigneeId !== undefined ? assigneeId : getLeastBusyUserId();
 
   let language = "en";
   let text = question;
@@ -1394,18 +1392,18 @@ app.get("/ai/agent-workload", (req, res) => {
 });
 
 // Estimate escalation risk
-app.get("/ai/escalation-risk", (req, res) => {
-  const now = Date.now();
-  const risks = data.tickets
-    .filter((t) => t.status !== "closed")
-    .map((t) => {
-      let score = 0.1;
-      if (t.priority === "high") score += 0.5;
-      if (t.dueDate && new Date(t.dueDate).getTime() < now) score += 0.4;
-      return { ticketId: t.id, risk: Math.min(score, 1) };
-    });
-  res.json(risks);
-
+  app.get("/ai/escalation-risk", (req, res) => {
+    const now = Date.now();
+    const risks = data.tickets
+      .filter((t) => t.status !== "closed")
+      .map((t) => {
+        let score = 0.1;
+        if (t.priority === "high") score += 0.5;
+        if (t.dueDate && new Date(t.dueDate).getTime() < now) score += 0.4;
+        return { ticketId: t.id, risk: Math.min(score, 1) };
+      });
+    res.json(risks);
+  });
 
 // Basic sentiment analysis for a text string
 app.post("/ai/sentiment", (req, res) => {
@@ -1413,6 +1411,7 @@ app.post("/ai/sentiment", (req, res) => {
   if (!text) return res.status(400).json({ error: "text required" });
   const sentiment = aiService.analyzeSentiment(text);
   res.json({ sentiment });
+});
 
 // Sentiment analysis endpoint
 app.post("/sentiment", (req, res) => {


### PR DESCRIPTION
## Summary
- create `mobile-app` directory initialized for Expo/React Native
- implement simple ticket list and detail screens
- add offline caching, biometric auth, camera attachments and notifications
- fix server syntax errors

## Testing
- `node run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_6875b1aa12a4832bb11e11fc76469bda