### PR TITLE
Remove token authentication

### DIFF
--- a/server.js
+++ b/server.js
@@ -68,15 +68,12 @@ app.post("/auth/login", (req, res) => {
   const { username, password } = req.body;
   const result = auth.authenticate(username, password);
   if (!result) return res.status(401).json({ error: "Invalid credentials" });
-  res.json(result);
+  res.json({ user: result.user });
 });
 
 app.get("/auth/verify", (req, res) => {
-  const token =
-    req.headers.authorization && req.headers.authorization.split(" ")[1];
-  const user = token && auth.verifyToken(token);
-  if (!user) return res.status(401).json({ error: "Invalid token" });
-  res.json({ user });
+  // Tokens are disabled; always return the first user
+  res.json({ user: data.users[0] });
 });
 
 // Basic health check endpoint
@@ -154,19 +151,8 @@ function getLeastBusyUserId() {
 
 // Authentication middleware
 app.use((req, res, next) => {
-  const authHeader = req.headers.authorization;
-  const token = authHeader && authHeader.split(' ')[1];
-  const payload = token && auth.verifyToken(token);
-  if (!payload) {
-    res.status(401).json({ error: 'Invalid token' });
-    return;
-  }
-  const user = data.users.find((u) => u.id === payload.id);
-  if (!user) {
-    res.status(401).json({ error: 'Invalid token' });
-    return;
-  }
-  req.user = user;
+  // Tokens are disabled; always use the first user
+  req.user = data.users[0];
   next();
 });
 

--- a/tests/authHeader.js
+++ b/tests/authHeader.js
@@ -1,14 +1,11 @@
 const http = require('http');
-const auth = require('../utils/authService');
 
-const { token } = auth.authenticate('Brian', 'password1');
-const authHeader = { Authorization: `Bearer ${token}` };
 
 function wrap(fn) {
   return function (options, ...args) {
     if (typeof options === 'string') options = new URL(options);
     else options = { ...options };
-    options.headers = { ...authHeader, ...(options.headers || {}) };
+    options.headers = { ...(options.headers || {}) };
     return fn.call(http, options, ...args);
   };
 }
@@ -16,4 +13,4 @@ function wrap(fn) {
 http.request = wrap(http.request);
 http.get = wrap(http.get);
 
-module.exports = { token, authHeader };
+module.exports = {};

--- a/utils/authService.js
+++ b/utils/authService.js
@@ -1,7 +1,6 @@
 const crypto = require("crypto");
 const data = require("../data/mockData");
 
-const SECRET = process.env.JWT_SECRET || "secret-key";
 
 function hashPassword(password) {
   return crypto
@@ -14,34 +13,12 @@ function authenticate(username, password) {
   const user = data.users.find((u) => u.name === username);
   if (!user) return null;
   if (user.passwordHash !== hashPassword(password)) return null;
-  const header = Buffer.from(
-    JSON.stringify({ alg: "HS256", typ: "JWT" })
-  ).toString("base64url");
-  const body = Buffer.from(
-    JSON.stringify({ id: user.id, name: user.name, exp: Date.now() + 3600_000 })
-  ).toString("base64url");
-  const signature = crypto
-    .createHmac("sha256", SECRET)
-    .update(`${header}.${body}`)
-    .digest("base64url");
-  const token = `${header}.${body}.${signature}`;
-  return { token };
+  return { user };
 }
 
 function verifyToken(token) {
-  try {
-    const [headerB64, bodyB64, sig] = token.split(".");
-    const expected = crypto
-      .createHmac("sha256", SECRET)
-      .update(`${headerB64}.${bodyB64}`)
-      .digest("base64url");
-    if (sig !== expected) return null;
-    const payload = JSON.parse(Buffer.from(bodyB64, "base64url").toString());
-    if (payload.exp < Date.now()) return null;
-    return payload;
-  } catch {
-    return null;
-  }
+  // Tokens are disabled
+  return null;
 }
 
 module.exports = { authenticate, verifyToken };


### PR DESCRIPTION
## Summary
- strip token logic from authService
- remove automatic auth header injection for tests
- disable token checks in server and always use first user

## Testing
- `npm test` *(fails: app.test.js socket hang up)*

------
https://chatgpt.com/codex/tasks/task_e_6875b7f710b4832bab75a81e11b140de