### PR TITLE
Fix categorize to handle empty text

### DIFF
--- a/frontend/src/components/AIAssistant.tsx
+++ b/frontend/src/components/AIAssistant.tsx
@@ -5,8 +5,8 @@ interface Ticket {
   question: string;
 }
 
-function categorize(text: string): string {
-  const t = text.toLowerCase();
+function categorize(text?: string): string {
+  const t = (text || '').toLowerCase();
   if (t.includes('password')) return 'authentication';
   if (t.includes('error')) return 'incident';
   return 'general';


### PR DESCRIPTION
## Summary
- handle undefined or empty text in the `categorize` helper

## Testing
- `npm run build` in `frontend`
- `npm test` *(fails: Error: socket hang up - app.test.js failed)*

------
https://chatgpt.com/codex/tasks/task_e_6876ec1669a8832b94e046e43ddef0cd