### PR TITLE
Fix header duplicate title

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,8 +24,6 @@ export default function App() {
           <Sidebar />
           <h1 className="text-2xl font-bold">AI Help Desk</h1>
         </div>
-
-        <h1 className="text-2xl font-bold">AI Help Desk</h1>
         <nav>
           <Link to="/" className="mr-4 text-primary dark:text-primary-dark hover:underline">Dashboard</Link>
           <Link to="/analytics" className="mr-4 text-primary dark:text-primary-dark hover:underline">Analytics</Link>


### PR DESCRIPTION
## Summary
- remove duplicate `<h1>` in App header
- build frontend

## Testing
- `npm run build`
- `npm test` *(fails: socket hang up)*

------
https://chatgpt.com/codex/tasks/task_e_6876ec1729fc832bb4fddfc294a0c7c8