### PR TITLE
Improve auth hashing and encryption

### DIFF
--- a/backend/services/securityManager.js
+++ b/backend/services/securityManager.js
@@ -39,21 +39,25 @@ function verifyJwt(token) {
 
 function encrypt(text, key) {
   const iv = crypto.randomBytes(16);
+  const salt = crypto.randomBytes(8);
   const cipher = crypto.createCipheriv(
     'aes-256-cbc',
-    crypto.scryptSync(key, 'salt', 32),
+    crypto.scryptSync(key, salt, 32),
     iv,
   );
   const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
-  return iv.toString('hex') + ':' + encrypted.toString('hex');
+  return (
+    salt.toString('hex') + ':' + iv.toString('hex') + ':' + encrypted.toString('hex')
+  );
 }
 
 function decrypt(payload, key) {
-  const [ivHex, dataHex] = payload.split(':');
+  const [saltHex, ivHex, dataHex] = payload.split(':');
   const iv = Buffer.from(ivHex, 'hex');
+  const salt = Buffer.from(saltHex, 'hex');
   const decipher = crypto.createDecipheriv(
     'aes-256-cbc',
-    crypto.scryptSync(key, 'salt', 32),
+    crypto.scryptSync(key, salt, 32),
     iv,
   );
   const decrypted = Buffer.concat([

--- a/data/mockData.js
+++ b/data/mockData.js
@@ -3,14 +3,16 @@ module.exports = {
     {
       id: 1,
       name: "Brian",
+      salt: "c611add510604607",
       passwordHash:
-        "b440f3cb3a08669827af2bed8c198cce8ae72e58fb7a3824ed3bdc00da1dc372",
+        "eb0412b9cbffea6e0c04371d0916ed33279aa2841ffcc5fb89fed640493db5ac",
     },
     {
       id: 2,
       name: "Alice",
+      salt: "70a0082def25687f",
       passwordHash:
-        "33f8f83f5d75b3c24d6335a161ed229a4a29db7dfa35730b2675deee83037b6c",
+        "138b21788bfc2745656abf0616264ee6b3773c0001c1ce5ee070c821ae99dcf5",
     },
   ],
   tickets: [

--- a/utils/authService.js
+++ b/utils/authService.js
@@ -2,17 +2,17 @@ const crypto = require("crypto");
 const data = require("../data/mockData");
 
 
-function hashPassword(password) {
+function hashPassword(salt, password) {
   return crypto
     .createHash("sha256")
-    .update("SALT123" + password)
+    .update(salt + password)
     .digest("hex");
 }
 
 function authenticate(username, password) {
   const user = data.users.find((u) => u.name === username);
   if (!user) return null;
-  if (user.passwordHash !== hashPassword(password)) return null;
+  if (user.passwordHash !== hashPassword(user.salt, password)) return null;
   return { user };
 }
 


### PR DESCRIPTION
## Summary
- store a salt with each user and use it when hashing passwords
- generate a random salt along with the IV for `encrypt()` and embed both in the ciphertext

## Testing
- `npm test` *(fails: socket hang up in app.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6876f4a53cb0832b9df0cc9c9ca25725