### PR TITLE
Add analytics websocket broadcasting

### DIFF
--- a/frontend/src/hooks/useAnalyticsSocket.ts
+++ b/frontend/src/hooks/useAnalyticsSocket.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react';
+
+export default function useAnalyticsSocket(handler: (data: any) => void) {
+  const cb = useRef(handler);
+  cb.current = handler;
+
+  useEffect(() => {
+    const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const ws = new WebSocket(`${proto}://${window.location.host}/ws/analytics`);
+    ws.onmessage = (ev) => {
+      try {
+        const msg = JSON.parse(ev.data);
+        cb.current(msg.data ?? msg);
+      } catch (err) {
+        console.error('analytics socket error', err);
+      }
+    };
+    return () => ws.close();
+  }, []);
+}

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,5 +1,6 @@
 
 import { useEffect, useRef, useState } from 'react';
+import useAnalyticsSocket from '../hooks/useAnalyticsSocket';
 
 
 interface PriorityStats {
@@ -26,6 +27,18 @@ export default function Analytics() {
   const [timeSeriesData, setTimeSeriesData] = useState<TimeSeriesData[]>([]);
   const [teamPerformance, setTeamPerformance] = useState<TeamPerformance[]>([]);
   const mainRef = useRef<HTMLElement | null>(null);
+
+  useAnalyticsSocket(update => {
+    if (update.priorityStats) {
+      setPriorityStats(prev => ({ ...prev, ...update.priorityStats }));
+    }
+    if (update.timeSeriesData) {
+      setTimeSeriesData(update.timeSeriesData);
+    }
+    if (update.teamPerformance) {
+      setTeamPerformance(update.teamPerformance);
+    }
+  });
 
   useEffect(() => {
     document.title = 'Analytics - AI Help Desk';

--- a/server.js
+++ b/server.js
@@ -1423,6 +1423,7 @@ if (require.main === module) {
   server.listen(PORT, () => console.log(`Server running on port ${PORT}`));
 
   wsServer.setupWebSocket(server);
+  wsServer.setupAnalyticsSocket(server);
 
 }
 

--- a/tests/analyticsRealtime.test.js
+++ b/tests/analyticsRealtime.test.js
@@ -1,0 +1,34 @@
+const http = require('http');
+const assert = require('assert');
+const WebSocket = require('ws');
+const app = require('../server');
+const { setupAnalyticsSocket } = require('../utils/websocketServer');
+
+const server = app.listen(0, () => {
+  const port = server.address().port;
+  setupAnalyticsSocket(server);
+
+  const ws = new WebSocket(`ws://localhost:${port}/ws/analytics`);
+  let got = false;
+
+  ws.on('message', msg => {
+    const data = JSON.parse(msg);
+    if (data.event === 'analytics') {
+      got = true;
+      ws.close();
+    }
+  });
+
+  ws.on('open', () => {
+    const req = http.request(
+      { port, path: '/tickets', method: 'POST', headers: { 'Content-Type': 'application/json' } },
+      () => {}
+    );
+    req.end(JSON.stringify({ question: 'test ticket', assigneeId: 1 }));
+  });
+
+  ws.on('close', () => {
+    assert.ok(got, 'should receive analytics update');
+    server.close(() => console.log('Analytics realtime test passed'));
+  });
+});

--- a/utils/websocketServer.js
+++ b/utils/websocketServer.js
@@ -3,6 +3,59 @@ const url = require('url');
 const eventBus = require('./eventBus');
 const data = require('../data/mockData');
 
+function buildAnalytics() {
+  const priorityStats = {};
+  data.tickets.forEach((t) => {
+    const p = t.priority || 'unspecified';
+    priorityStats[p] = (priorityStats[p] || 0) + 1;
+  });
+
+  const days = 7;
+  const now = new Date();
+  const timeSeriesData = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(now.getTime() - i * 86400000)
+      .toISOString()
+      .slice(0, 10);
+    const created = data.tickets.filter((t) => {
+      const h = (t.history || []).find((e) => e.action === 'created');
+      return h && h.date.slice(0, 10) === d;
+    }).length;
+    const resolved = data.tickets.filter((t) => {
+      const h = (t.history || []).find(
+        (e) => e.action === 'status' && e.to === 'closed'
+      );
+      return h && h.date.slice(0, 10) === d;
+    }).length;
+    timeSeriesData.push({ date: d, tickets: created, resolved });
+  }
+
+  const teamPerformance = data.users.map((u) => {
+    const closed = data.tickets.filter(
+      (t) => t.assigneeId === u.id && t.status === 'closed'
+    );
+    const resolved = closed.length;
+    let sum = 0;
+    closed.forEach((t) => {
+      const created = (t.history || []).find((h) => h.action === 'created');
+      const close = (t.history || []).find(
+        (h) => h.action === 'status' && h.to === 'closed'
+      );
+      if (created && close)
+        sum += new Date(close.date) - new Date(created.date);
+    });
+    const avgTime = resolved ? (sum / resolved) / 3600000 : 0;
+    return {
+      name: u.name,
+      resolved,
+      avgTime: `${avgTime.toFixed(1)}h`,
+      satisfaction: 4.5,
+    };
+  });
+
+  return { priorityStats, timeSeriesData, teamPerformance };
+}
+
 // Map of ws -> userId
 const clients = new Map();
 // Set of online user ids
@@ -68,4 +121,28 @@ function getPresence() {
   return Array.from(online).map((id) => data.users.find((u) => u.id === id));
 }
 
-module.exports = { setupWebSocket, getPresence };
+function setupAnalyticsSocket(server) {
+  const wss = new WebSocket.Server({ noServer: true });
+
+  server.on('upgrade', (req, socket, head) => {
+    const pathname = url.parse(req.url).pathname;
+    if (pathname === '/ws/analytics') {
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        const payload = buildAnalytics();
+        ws.send(JSON.stringify({ event: 'analytics', data: payload }));
+      });
+    }
+  });
+
+  const push = () => {
+    const payload = buildAnalytics();
+    broadcast({ event: 'analytics', data: payload }, wss);
+  };
+
+  eventBus.on('ticketCreated', push);
+  eventBus.on('ticketUpdated', push);
+
+  return wss;
+}
+
+module.exports = { setupWebSocket, getPresence, setupAnalyticsSocket };


### PR DESCRIPTION
## Summary
- extend websocket server with analytics broadcasting
- start analytics socket under `/ws/analytics`
- subscribe to analytics updates in `Analytics.tsx`
- add hook for analytics socket
- test realtime analytics websocket

## Testing
- `node tests/analyticsRealtime.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6876f595f1d0832bb56b90537bae728b