### PR TITLE
Use configurable CORS origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Other useful environment variables include:
 - `OPENAI_API_KEY` – API key for calling OpenAI services used by `aiService`.
 - `TRANSLATE_URL` – HTTP endpoint for the translation service.
 - `TRANSLATE_API_KEY` – API key used when contacting the translation provider.
-- `CORS_ORIGIN` – allowed origin for the React frontend.
+- `CORS_ORIGIN` – origin used for the `Access-Control-Allow-Origin` response header (e.g. `http://localhost:5173`).
 - `DEFAULT_LANGUAGE` – default language code for translations.
 
 After the first visit, the pages are cached for offline use via a service worker.

--- a/server.js
+++ b/server.js
@@ -49,8 +49,12 @@ app.use((req, res, next) => {
   }
   next();
 });
+const CORS_ORIGIN = process.env.CORS_ORIGIN;
+
 app.use((req, res, next) => {
-  res.setHeader("Access-Control-Allow-Origin", "*");
+  if (CORS_ORIGIN) {
+    res.setHeader("Access-Control-Allow-Origin", CORS_ORIGIN);
+  }
   res.setHeader(
     "Access-Control-Allow-Methods",
     "GET,POST,PATCH,DELETE,OPTIONS",

--- a/tests/cors.test.js
+++ b/tests/cors.test.js
@@ -1,14 +1,15 @@
 const http = require('http');
 const assert = require('assert');
+process.env.CORS_ORIGIN = 'http://test.example';
 const app = require('../server');
 
 const server = app.listen(0, () => {
   const port = server.address().port;
   http.get({ port, path: '/health' }, res => {
-    assert.strictEqual(res.headers['access-control-allow-origin'], '*');
+    assert.strictEqual(res.headers['access-control-allow-origin'], 'http://test.example');
     const req = http.request({ port, path: '/tickets', method: 'OPTIONS' }, res2 => {
       assert.strictEqual(res2.statusCode, 204);
-      assert.strictEqual(res2.headers['access-control-allow-origin'], '*');
+      assert.strictEqual(res2.headers['access-control-allow-origin'], 'http://test.example');
       server.close(() => console.log('CORS test passed'));
     });
     req.end();


### PR DESCRIPTION
## Summary
- support `process.env.CORS_ORIGIN` in the Express server
- clarify usage of `CORS_ORIGIN` in the README
- update the CORS test to verify the configured origin

## Testing
- `npm install`
- `npm test` *(fails: Error: socket hang up)*

------
https://chatgpt.com/codex/tasks/task_e_6876f4a3d5c0832b9a0f82b7cd853814