### PR TITLE
Fix duplicate attachSocket definition

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,21 +20,11 @@ const sentimentService = require("./utils/sentimentService");
 const assistant = require("./utils/assistant");
 
 const http = require('http');
-const { Server } = require('socket.io');
-
-
 
 const fs = require('fs');
 const { Server: IOServer } = require('socket.io');
 const app = express();
 
-function attachSocket(server) {
-  const io = new Server(server);
-  eventBus.on('ticketCreated', (t) => io.emit('ticketCreated', t));
-  eventBus.on('ticketUpdated', (t) => io.emit('ticketUpdated', t));
-  server.on('close', () => io.close());
-  return io;
-}
 app.use(bodyParser.json());
 
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
## Summary
- remove early `attachSocket` implementation
- drop unused `Server` import
- keep final `attachSocket` in use

## Testing
- `npm test` *(fails: Error: app.test.js failed)*

------
https://chatgpt.com/codex/tasks/task_e_6876f594fb00832b8afc366223237617