### PR TITLE
Enable realtime analytics updates over websockets

### DIFF
--- a/frontend/src/hooks/useAnalyticsSocket.ts
+++ b/frontend/src/hooks/useAnalyticsSocket.ts
@@ -1,8 +1,13 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useState } from 'react';
 
-export default function useAnalyticsSocket(handler: (data: any) => void) {
-  const cb = useRef(handler);
-  cb.current = handler;
+export interface AnalyticsUpdate {
+  priorityStats?: Record<string, number>;
+  timeSeriesData?: any[];
+  teamPerformance?: any[];
+}
+
+export default function useAnalyticsSocket() {
+  const [update, setUpdate] = useState<AnalyticsUpdate>({});
 
   useEffect(() => {
     const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
@@ -10,11 +15,13 @@ export default function useAnalyticsSocket(handler: (data: any) => void) {
     ws.onmessage = (ev) => {
       try {
         const msg = JSON.parse(ev.data);
-        cb.current(msg.data ?? msg);
+        setUpdate((u) => ({ ...u, ...(msg.data ?? msg) }));
       } catch (err) {
         console.error('analytics socket error', err);
       }
     };
     return () => ws.close();
   }, []);
+
+  return update;
 }

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -24,22 +24,27 @@ interface HeatCell {
 export default function Analytics() {
   const [filters, setFilters] = useState<AnalyticsFilters>({});
   const [series, setSeries] = useState<SeriesPoint[]>([]);
+  const [priorityStats, setPriorityStats] = useState<Record<string, number>>({});
+  const [timeSeriesData, setTimeSeriesData] = useState<SeriesPoint[]>([]);
+  const [teamPerformance, setTeamPerformance] = useState<any[]>([]);
   const [priority, setPriority] = useState<Record<string, number>>({});
   const [forecast, setForecast] = useState<number[]>([]);
   const [heat, setHeat] = useState<HeatCell[]>([]);
   const heatRef = useRef<HTMLCanvasElement>(null);
 
-  useAnalyticsSocket(update => {
-    if (update.priorityStats) {
-      setPriorityStats(prev => ({ ...prev, ...update.priorityStats }));
+  const updates = useAnalyticsSocket();
+
+  useEffect(() => {
+    if (updates.priorityStats) {
+      setPriorityStats(prev => ({ ...prev, ...updates.priorityStats! }));
     }
-    if (update.timeSeriesData) {
-      setTimeSeriesData(update.timeSeriesData);
+    if (updates.timeSeriesData) {
+      setTimeSeriesData(updates.timeSeriesData);
     }
-    if (update.teamPerformance) {
-      setTeamPerformance(update.teamPerformance);
+    if (updates.teamPerformance) {
+      setTeamPerformance(updates.teamPerformance);
     }
-  });
+  }, [updates]);
 
   useEffect(() => {
     document.title = 'Analytics - AI Help Desk';

--- a/server.js
+++ b/server.js
@@ -17,6 +17,7 @@ const reportExporter = require("./utils/reportExporter");
 
 const translation = require("./utils/translationService");
 const sentimentService = require("./utils/sentimentService");
+const url = require('url');
 
 const assistant = require("./utils/assistant");
 
@@ -1493,7 +1494,13 @@ if (require.main === module) {
   server.listen(PORT, () => console.log(`Server running on port ${PORT}`));
 
   wsServer.setupWebSocket(server);
-  wsServer.setupAnalyticsSocket(server);
+  const analyticsWSS = wsServer.createAnalyticsWSS();
+  server.on('upgrade', (req, socket, head) => {
+    const pathname = url.parse(req.url).pathname;
+    if (pathname === '/ws/analytics') {
+      wsServer.analyticsUpgradeHandler(analyticsWSS, req, socket, head);
+    }
+  });
 
 }
 


### PR DESCRIPTION
## Summary
- broadcast analytics data via websocket helpers
- hook server upgrade event for `/ws/analytics`
- expose analytics websocket data in a React hook and subscribe in Analytics page

## Testing
- `npm test` *(fails: socket hang up)*

------
https://chatgpt.com/codex/tasks/task_e_687846aff3f4832b9983f592d24e450c