### PR TITLE
Fix trending icon import

### DIFF
--- a/frontend/src/pages/AnimatedDashboard.tsx
+++ b/frontend/src/pages/AnimatedDashboard.tsx
@@ -1,14 +1,14 @@
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-  TrendingUpIcon,
+  ArrowTrendingUpIcon as TrendingUpIcon,
   ClockIcon,
   TicketIcon,
   UserGroupIcon,
   ChartBarIcon,
   FireIcon,
   CheckCircleIcon,
-  ExclamationTriangleIcon
+  ExclamationTriangleIcon,
 } from '@heroicons/react/24/outline';
 
 interface Ticket {


### PR DESCRIPTION
## Summary
- update heroicons import for new `ArrowTrendingUpIcon` alias in `AnimatedDashboard`

## Testing
- `npm test` *(fails: socket hang up during app.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68784ba3c0d4832b8f3693472740766f