### PR TITLE
Fix useQuery signature in KPI and sidebar components

### DIFF
--- a/frontend/src/components/KPICards.tsx
+++ b/frontend/src/components/KPICards.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery } from "@tanstack/react-query";
 
 interface DashboardStats {
   tickets: { open: number; waiting: number; closed: number };
@@ -17,25 +17,31 @@ function KPICard({ label, value }: { label: string; value: number | string }) {
 }
 
 export default function KPICards() {
-  const { data } = useQuery<DashboardStats>(['kpi'], async () => {
-    const res = await fetch('/stats/dashboard');
-    return res.json();
+  const { data } = useQuery<DashboardStats>({
+    queryKey: ["kpi"],
+    queryFn: async () => {
+      const res = await fetch("/stats/dashboard");
+      return res.json();
+    },
   });
 
   if (!data) return <p>Loading...</p>;
 
   const cards = [
-    { label: 'Open', value: data.tickets.open },
-    { label: 'Waiting', value: data.tickets.waiting },
-    { label: 'Closed', value: data.tickets.closed },
-    { label: 'Forecast', value: data.forecast.toFixed(1) },
-    { label: 'MTTR', value: `${data.mttr.toFixed(1)}h` },
-    { label: 'Assets', value: data.assets.total },
+    { label: "Open", value: data.tickets.open },
+    { label: "Waiting", value: data.tickets.waiting },
+    { label: "Closed", value: data.tickets.closed },
+    { label: "Forecast", value: data.forecast.toFixed(1) },
+    { label: "MTTR", value: `${data.mttr.toFixed(1)}h` },
+    { label: "Assets", value: data.assets.total },
   ];
 
   return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" aria-live="polite">
-      {cards.map(c => (
+    <div
+      className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
+      aria-live="polite"
+    >
+      {cards.map((c) => (
         <KPICard key={c.label} label={c.label} value={c.value} />
       ))}
     </div>

--- a/frontend/src/components/RightSidebar.tsx
+++ b/frontend/src/components/RightSidebar.tsx
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-import useRealtime from '../hooks/useRealtime';
+import { useQuery } from "@tanstack/react-query";
+import useRealtime from "../hooks/useRealtime";
 
 interface Activity {
   id: string;
@@ -9,17 +9,20 @@ interface Activity {
 }
 
 function TeamActivityFeed() {
-  const { data, refetch } = useQuery<Activity[]>(['activity'], async () => {
-    const res = await fetch('/api/activity');
-    return res.json();
+  const { data, refetch } = useQuery<Activity[]>({
+    queryKey: ["activity"],
+    queryFn: async () => {
+      const res = await fetch("/api/activity");
+      return res.json();
+    },
   });
-  useRealtime('activity', () => refetch());
+  useRealtime("activity", () => refetch());
   if (!data) return <p>Loading...</p>;
   return (
     <div className="bg-white dark:bg-gray-800 p-4 rounded-xl shadow h-64 overflow-auto">
       <h2 className="font-semibold mb-2">Team Activity</h2>
       <ul className="space-y-2 text-sm">
-        {data.map(a => (
+        {data.map((a) => (
           <li key={a.id} className="border-b pb-1">
             <span className="font-medium">{a.user.name}</span> {a.message}
           </li>
@@ -33,9 +36,15 @@ function QuickActionsPanel() {
   return (
     <div className="bg-white dark:bg-gray-800 p-4 rounded-xl shadow space-y-2">
       <h2 className="font-semibold mb-2">Quick Actions</h2>
-      <button className="w-full bg-blue-600 text-white rounded p-2">New Ticket</button>
-      <button className="w-full bg-green-600 text-white rounded p-2">Bulk Assign</button>
-      <button className="w-full bg-purple-600 text-white rounded p-2">Generate Report</button>
+      <button className="w-full bg-blue-600 text-white rounded p-2">
+        New Ticket
+      </button>
+      <button className="w-full bg-green-600 text-white rounded p-2">
+        Bulk Assign
+      </button>
+      <button className="w-full bg-purple-600 text-white rounded p-2">
+        Generate Report
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update `useQuery` calls in `KPICards` and `RightSidebar`
- run project formatter and rebuild frontend

## Testing
- `npm run format` *(fails: Unexpected token in frontend/tailwind.config.js)*
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_68784f2c21f0832b9af57382866c7fb0